### PR TITLE
feat: Add GoReleaser and Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,70 +7,30 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
-  release:
-    name: Create Release
+  goreleaser:
+    name: Release with GoReleaser
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.23'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
 
-    - name: Get version from tag
-      id: get_version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-    - name: Build binaries
-      env:
-        VERSION: ${{ steps.get_version.outputs.VERSION }}
-      run: |
-        make release
-
-    - name: Create checksums
-      run: |
-        cd dist
-        sha256sum * > checksums.txt
-        cat checksums.txt
-
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Get the previous tag
-        PREV_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1) 2>/dev/null || echo "")
-
-        if [ -z "$PREV_TAG" ]; then
-          # First release - get all commits
-          CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges)
-        else
-          # Get commits since previous tag
-          CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
-        fi
-
-        # Save to file for release notes
-        echo "$CHANGELOG" > CHANGELOG.txt
-        cat CHANGELOG.txt
-
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
-      with:
-        name: Release v${{ steps.get_version.outputs.VERSION }}
-        body_path: CHANGELOG.txt
-        files: |
-          dist/canvas-*
-          dist/checksums.txt
-        draft: false
-        prerelease: false
-
-    - name: Update Homebrew Formula
-      if: "!contains(github.ref, 'beta') && !contains(github.ref, 'rc')"
-      run: |
-        echo "TODO: Update Homebrew formula"
-        # This would be implemented to update a Homebrew tap repository
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,129 @@
+# GoReleaser configuration for Canvas CLI
+# Documentation: https://goreleaser.com
+
+version: 2
+
+project_name: canvas-cli
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: canvas
+    main: ./cmd/canvas
+    binary: canvas
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - '^chore:'
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: 'New Features'
+      regexp: '^feat'
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: '^fix'
+      order: 1
+    - title: 'Performance Improvements'
+      regexp: '^perf'
+      order: 2
+    - title: 'Other Changes'
+      order: 999
+
+release:
+  github:
+    owner: jjuanrivvera
+    name: canvas-cli
+  draft: false
+  prerelease: auto
+  name_template: "v{{.Version}}"
+  header: |
+    ## Canvas CLI v{{.Version}}
+
+    ### Installation
+
+    **Homebrew (macOS/Linux)**
+    ```bash
+    brew tap jjuanrivvera/canvas-cli
+    brew install canvas-cli
+    ```
+
+    **Go**
+    ```bash
+    go install github.com/jjuanrivvera/canvas-cli/cmd/canvas@v{{.Version}}
+    ```
+
+    **Binary Download**
+    Download the appropriate archive for your platform below.
+
+brews:
+  - name: canvas-cli
+    ids:
+      - default
+    repository:
+      owner: jjuanrivvera
+      name: homebrew-canvas-cli
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/jjuanrivvera/canvas-cli"
+    description: "A powerful command-line interface for Canvas LMS"
+    license: "MIT"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    test: |
+      system "#{bin}/canvas", "version"
+    install: |
+      bin.install "canvas"


### PR DESCRIPTION
## Summary
- Add GoReleaser configuration for automated releases
- Set up Homebrew tap at `jjuanrivvera/homebrew-canvas-cli`
- Replace manual release workflow with GoReleaser action

## Changes
- `.goreleaser.yaml` - GoReleaser configuration with multi-platform builds and Homebrew formula updates
- `.github/workflows/release.yml` - Simplified workflow using GoReleaser action

## Homebrew Installation
After releasing, users can install via:
```bash
brew tap jjuanrivvera/canvas-cli
brew install canvas-cli
```

## Test plan
- [ ] Merge to main
- [ ] Create tag `v1.2.0`
- [ ] Verify release artifacts are created
- [ ] Verify Homebrew formula is updated
- [ ] Test `brew install jjuanrivvera/canvas-cli/canvas-cli`