### PR TITLE
feat: use positional argument for instance name in config add

### DIFF
--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -140,13 +140,13 @@ Canvas CLI supports multiple Canvas installations:
 
 ```bash
 # Add production instance
-canvas config add --name production --url https://canvas.instructure.com
+canvas config add production --url https://canvas.instructure.com
 
 # Add staging instance
-canvas config add --name staging --url https://staging.canvas.instructure.com
+canvas config add staging --url https://staging.canvas.instructure.com
 
 # Add self-hosted instance
-canvas config add --name onprem --url https://canvas.company.com
+canvas config add onprem --url https://canvas.company.com
 ```
 
 ### Switch Between Instances

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,7 +20,7 @@ This will open your browser for OAuth authentication. After authorizing, you'll 
 !!! tip "API Token Alternative"
     If OAuth isn't available, you can use an API token:
     ```bash
-    canvas config add --name mycanvas --url https://canvas.example.com --token YOUR_API_TOKEN
+    canvas config add mycanvas --url https://canvas.example.com --token YOUR_API_TOKEN
     ```
 
 ## Step 2: Verify Authentication

--- a/docs/tutorials/course-sync.md
+++ b/docs/tutorials/course-sync.md
@@ -22,10 +22,10 @@ First, set up both Canvas instances:
 
 ```bash
 # Add production instance
-canvas config add --name production --url https://canvas.example.com --token YOUR_PROD_TOKEN
+canvas config add production --url https://canvas.example.com --token YOUR_PROD_TOKEN
 
 # Add sandbox instance
-canvas config add --name sandbox --url https://canvas-sandbox.example.com --token YOUR_SANDBOX_TOKEN
+canvas config add sandbox --url https://canvas-sandbox.example.com --token YOUR_SANDBOX_TOKEN
 ```
 
 Verify your instances:
@@ -138,7 +138,7 @@ Sync course content between institutions:
 
 ```bash
 # Configure second institution
-canvas config add --name partner --url https://partner.instructure.com --token TOKEN
+canvas config add partner --url https://partner.instructure.com --token TOKEN
 
 # Sync course
 canvas sync course 123 --from production --to partner --all

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -23,10 +23,10 @@ instances:
 
 ```bash
 # Add with API token
-canvas config add --name production --url https://canvas.example.com --token YOUR_TOKEN
+canvas config add production --url https://canvas.example.com --token YOUR_TOKEN
 
 # Add without token (will prompt for OAuth)
-canvas config add --name production --url https://canvas.example.com
+canvas config add production --url https://canvas.example.com
 ```
 
 ### List Instances


### PR DESCRIPTION
## Summary

- Change `config add` to accept name as positional argument instead of `--name` flag
- Update all documentation to reflect the new syntax

**Before:**
```bash
canvas config add --name prod --url https://acue.instructure.com
```

**After:**
```bash
canvas config add prod --url https://acue.instructure.com
```

## Rationale

This follows common CLI patterns:
- `git remote add origin https://...`
- `kubectl config set-cluster mycluster --server=...`
- `docker context create mycontext --docker "host=..."`

The name is short and always required (natural as positional), while URL is a longer value that works better as a flag.

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Manual testing: `canvas config add testinstance --url https://test.instructure.com`
- [x] Documentation updated