### PR TITLE
feat: implement automatic OAuth token refresh

### DIFF
--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// RefreshBuffer is the time before expiry when we proactively refresh
+// This prevents requests from failing due to token expiry during the request
+const RefreshBuffer = 5 * time.Minute
+
+// AutoRefreshTokenSource wraps an oauth2.TokenSource with automatic persistence
+// of refreshed tokens. It proactively refreshes tokens before they expire.
+type AutoRefreshTokenSource struct {
+	oauth2Config *oauth2.Config
+	store        TokenStore
+	instanceName string
+	token        *oauth2.Token
+	mu           sync.Mutex
+}
+
+// NewAutoRefreshTokenSource creates a token source that automatically refreshes
+// expired tokens and saves them to the provided store.
+func NewAutoRefreshTokenSource(
+	oauth2Config *oauth2.Config,
+	store TokenStore,
+	instanceName string,
+	token *oauth2.Token,
+) *AutoRefreshTokenSource {
+	return &AutoRefreshTokenSource{
+		oauth2Config: oauth2Config,
+		store:        store,
+		instanceName: instanceName,
+		token:        token,
+	}
+}
+
+// Token returns a valid token, refreshing if necessary.
+// If the token is refreshed, it is automatically saved to storage.
+func (s *AutoRefreshTokenSource) Token() (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if token is still valid with buffer time
+	if s.token.Valid() && time.Until(s.token.Expiry) > RefreshBuffer {
+		return s.token, nil
+	}
+
+	// Token is expired or about to expire, refresh it
+	if s.token.RefreshToken == "" {
+		return nil, fmt.Errorf("token expired and no refresh token available. Run 'canvas auth login' to re-authenticate")
+	}
+
+	// Create a token source for refresh
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ts := s.oauth2Config.TokenSource(ctx, s.token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh token: %w. Run 'canvas auth login' to re-authenticate", err)
+	}
+
+	// Save the refreshed token
+	if err := s.store.Save(s.instanceName, newToken); err != nil {
+		// Log but don't fail - token is still valid for this session
+		fmt.Printf("Warning: failed to save refreshed token: %v\n", err)
+	}
+
+	s.token = newToken
+	return newToken, nil
+}
+
+// GetAccessToken is a convenience method that returns just the access token string.
+// This is useful when you only need the bearer token for API calls.
+func (s *AutoRefreshTokenSource) GetAccessToken() (string, error) {
+	token, err := s.Token()
+	if err != nil {
+		return "", err
+	}
+	return token.AccessToken, nil
+}
+
+// IsExpired checks if the current token is expired or about to expire.
+func (s *AutoRefreshTokenSource) IsExpired() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.token.Valid() || time.Until(s.token.Expiry) <= RefreshBuffer
+}
+
+// CreateOAuth2ConfigForInstance creates an oauth2.Config for token refresh operations.
+// This is used when we need to refresh a token but don't have the full OAuthFlow.
+func CreateOAuth2ConfigForInstance(baseURL, clientID, clientSecret string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  baseURL + "/login/oauth2/auth",
+			TokenURL: baseURL + "/login/oauth2/token",
+		},
+	}
+}

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -1,0 +1,240 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// mockTokenStore implements TokenStore for testing
+type mockTokenStore struct {
+	tokens map[string]*oauth2.Token
+}
+
+func newMockTokenStore() *mockTokenStore {
+	return &mockTokenStore{tokens: make(map[string]*oauth2.Token)}
+}
+
+func (m *mockTokenStore) Save(instanceName string, token *oauth2.Token) error {
+	m.tokens[instanceName] = token
+	return nil
+}
+
+func (m *mockTokenStore) Load(instanceName string) (*oauth2.Token, error) {
+	if token, ok := m.tokens[instanceName]; ok {
+		return token, nil
+	}
+	return nil, nil
+}
+
+func (m *mockTokenStore) Delete(instanceName string) error {
+	delete(m.tokens, instanceName)
+	return nil
+}
+
+func (m *mockTokenStore) Exists(instanceName string) bool {
+	_, ok := m.tokens[instanceName]
+	return ok
+}
+
+func TestAutoRefreshTokenSource_ValidToken(t *testing.T) {
+	// Create a valid token that expires in 1 hour
+	token := &oauth2.Token{
+		AccessToken:  "valid-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	// Get token - should return the same token without refresh
+	result, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+
+	if result.AccessToken != "valid-access-token" {
+		t.Errorf("Token() AccessToken = %v, want %v", result.AccessToken, "valid-access-token")
+	}
+}
+
+func TestAutoRefreshTokenSource_GetAccessToken(t *testing.T) {
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	// Test GetAccessToken convenience method
+	accessToken, err := ts.GetAccessToken()
+	if err != nil {
+		t.Fatalf("GetAccessToken() error = %v", err)
+	}
+
+	if accessToken != "test-access-token" {
+		t.Errorf("GetAccessToken() = %v, want %v", accessToken, "test-access-token")
+	}
+}
+
+func TestAutoRefreshTokenSource_IsExpired_ValidToken(t *testing.T) {
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	if ts.IsExpired() {
+		t.Errorf("IsExpired() = true for token expiring in 1 hour")
+	}
+}
+
+func TestAutoRefreshTokenSource_IsExpired_ExpiredToken(t *testing.T) {
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(-1 * time.Hour), // Expired 1 hour ago
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	if !ts.IsExpired() {
+		t.Errorf("IsExpired() = false for token expired 1 hour ago")
+	}
+}
+
+func TestAutoRefreshTokenSource_IsExpired_NearExpiry(t *testing.T) {
+	// Token expiring within RefreshBuffer should be considered expired
+	token := &oauth2.Token{
+		AccessToken:  "test-access-token",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(2 * time.Minute), // Expires in 2 minutes (< 5 min buffer)
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	if !ts.IsExpired() {
+		t.Errorf("IsExpired() = false for token expiring in 2 minutes (within buffer)")
+	}
+}
+
+func TestAutoRefreshTokenSource_NoRefreshToken(t *testing.T) {
+	// Create an expired token with no refresh token
+	token := &oauth2.Token{
+		AccessToken:  "expired-access-token",
+		RefreshToken: "", // No refresh token
+		Expiry:       time.Now().Add(-1 * time.Hour),
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	// Should error when trying to refresh
+	_, err := ts.Token()
+	if err == nil {
+		t.Errorf("Token() should error when expired with no refresh token")
+	}
+}
+
+func TestAutoRefreshTokenSource_RefreshAndSave(t *testing.T) {
+	// Create a mock OAuth2 server that returns a new token
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a new token
+		response := map[string]interface{}{
+			"access_token":  "new-access-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"refresh_token": "new-refresh-token",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create an expired token
+	token := &oauth2.Token{
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		Expiry:       time.Now().Add(-1 * time.Hour), // Expired
+	}
+
+	store := newMockTokenStore()
+	oauth2Config := &oauth2.Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: server.URL,
+		},
+	}
+
+	ts := NewAutoRefreshTokenSource(oauth2Config, store, "test-instance", token)
+
+	// Get token - should trigger refresh
+	result, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+
+	// Check that we got the new token
+	if result.AccessToken != "new-access-token" {
+		t.Errorf("Token() AccessToken = %v, want %v", result.AccessToken, "new-access-token")
+	}
+
+	// Check that the token was saved to storage
+	savedToken, _ := store.Load("test-instance")
+	if savedToken == nil {
+		t.Errorf("Token was not saved to storage")
+	} else if savedToken.AccessToken != "new-access-token" {
+		t.Errorf("Saved token AccessToken = %v, want %v", savedToken.AccessToken, "new-access-token")
+	}
+}
+
+func TestCreateOAuth2ConfigForInstance(t *testing.T) {
+	config := CreateOAuth2ConfigForInstance(
+		"https://canvas.example.com",
+		"client-123",
+		"secret-456",
+	)
+
+	if config.ClientID != "client-123" {
+		t.Errorf("ClientID = %v, want %v", config.ClientID, "client-123")
+	}
+
+	if config.ClientSecret != "secret-456" {
+		t.Errorf("ClientSecret = %v, want %v", config.ClientSecret, "secret-456")
+	}
+
+	expectedAuthURL := "https://canvas.example.com/login/oauth2/auth"
+	if config.Endpoint.AuthURL != expectedAuthURL {
+		t.Errorf("AuthURL = %v, want %v", config.Endpoint.AuthURL, expectedAuthURL)
+	}
+
+	expectedTokenURL := "https://canvas.example.com/login/oauth2/token"
+	if config.Endpoint.TokenURL != expectedTokenURL {
+		t.Errorf("TokenURL = %v, want %v", config.Endpoint.TokenURL, expectedTokenURL)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements automatic OAuth token refresh to prevent session failures due to expired tokens
- Adds `AutoRefreshTokenSource` that proactively refreshes tokens 5 minutes before expiry
- Tokens are automatically persisted to storage after refresh
- Backward compatible - static tokens still work for CI/CD environments

## Changes

- `internal/auth/token_source.go` - New auto-refreshing token source
- `internal/api/client.go` - Support for TokenSource in ClientConfig
- `commands/helpers.go` - Use auto-refresh when OAuth credentials available
- `commands/sync.go` - Use auto-refresh for sync operations

## How it works

1. When a token is about to expire (within 5 min buffer), the `AutoRefreshTokenSource` automatically requests a new token using the refresh token
2. The new token is saved to the token store (keyring or encrypted file)
3. The API client uses the fresh token for requests

## Requirements

Auto-refresh requires OAuth credentials (client ID and client secret) to be stored with the instance. Instances without OAuth credentials fall back to static tokens.

## Test plan

- [x] Run existing tests - all pass
- [x] Add tests for `AutoRefreshTokenSource`
- [x] Test token validity checks
- [x] Test refresh and persist behavior