### PR TITLE
feat: add aggressive auto-update functionality

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -442,6 +442,8 @@ func runConfigShow(ctx context.Context, opts *options.ConfigShowOptions) error {
 		fmt.Printf("  Cache TTL: %d minutes\n", cfg.Settings.CacheTTL)
 		fmt.Printf("  Telemetry: %t\n", cfg.Settings.TelemetryEnabled)
 		fmt.Printf("  Log level: %s\n", cfg.Settings.LogLevel)
+		fmt.Printf("  Auto-update: %t\n", cfg.Settings.AutoUpdateEnabled)
+		fmt.Printf("  Auto-update interval: %d minutes\n", cfg.Settings.AutoUpdateIntervalMin)
 	}
 
 	logger.LogCommandComplete(ctx, "config.show", 1)

--- a/commands/internal/options/update.go
+++ b/commands/internal/options/update.go
@@ -1,0 +1,46 @@
+package options
+
+// UpdateOptions holds options for the update command
+type UpdateOptions struct{}
+
+// Validate validates the update options
+func (o *UpdateOptions) Validate() error {
+	return nil
+}
+
+// UpdateCheckOptions holds options for the update check command
+type UpdateCheckOptions struct{}
+
+// Validate validates the update check options
+func (o *UpdateCheckOptions) Validate() error {
+	return nil
+}
+
+// UpdateEnableOptions holds options for the update enable command
+type UpdateEnableOptions struct {
+	Interval int
+}
+
+// Validate validates the update enable options
+func (o *UpdateEnableOptions) Validate() error {
+	if o.Interval < 1 {
+		o.Interval = 60 // Default to 60 minutes
+	}
+	return nil
+}
+
+// UpdateDisableOptions holds options for the update disable command
+type UpdateDisableOptions struct{}
+
+// Validate validates the update disable options
+func (o *UpdateDisableOptions) Validate() error {
+	return nil
+}
+
+// UpdateStatusOptions holds options for the update status command
+type UpdateStatusOptions struct{}
+
+// Validate validates the update status options
+func (o *UpdateStatusOptions) Validate() error {
+	return nil
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -54,8 +54,8 @@ Examples:
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		// Print any update notifications after command completes
 		if autoUpdater != nil {
-			// Small delay to allow async update to complete
-			time.Sleep(100 * time.Millisecond)
+			// Wait for async update check to complete (with timeout to avoid blocking forever)
+			autoUpdater.WaitForCompletion(5 * time.Second)
 			autoUpdater.PrintNotifications()
 		}
 	},

--- a/commands/update.go
+++ b/commands/update.go
@@ -1,0 +1,243 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
+	"github.com/jjuanrivvera/canvas-cli/internal/update"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Check for and install updates",
+	Long: `Check for new versions of canvas-cli and install them automatically.
+
+The CLI automatically checks for updates in the background. You can use this
+command to check immediately or configure auto-update behavior.
+
+Examples:
+  canvas update              # Check and install updates now
+  canvas update --check      # Check for updates without installing
+  canvas update --disable    # Disable auto-updates
+  canvas update --enable     # Enable auto-updates
+  canvas update --status     # Show auto-update status`,
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+	updateCmd.AddCommand(newUpdateCheckCmd())
+	updateCmd.AddCommand(newUpdateEnableCmd())
+	updateCmd.AddCommand(newUpdateDisableCmd())
+	updateCmd.AddCommand(newUpdateStatusCmd())
+
+	// Default action for `canvas update` (no subcommand)
+	updateCmd.RunE = runUpdateNow
+}
+
+func newUpdateCheckCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Short: "Check for updates without installing",
+		RunE:  runUpdateCheck,
+	}
+}
+
+func newUpdateEnableCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable automatic updates",
+		RunE:  runUpdateEnable,
+	}
+
+	cmd.Flags().Int("interval", 60, "Check interval in minutes (default 60)")
+	return cmd
+}
+
+func newUpdateDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable automatic updates",
+		RunE:  runUpdateDisable,
+	}
+}
+
+func newUpdateStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show auto-update status and configuration",
+		RunE:  runUpdateStatus,
+	}
+}
+
+func runUpdateNow(cmd *cobra.Command, args []string) error {
+	fmt.Println("Checking for updates...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	updater := update.NewUpdater(version)
+	release, err := updater.GetLatestRelease(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	latestVersion := release.TagName
+	fmt.Printf("Current version: %s\n", version)
+	fmt.Printf("Latest version:  %s\n", latestVersion)
+
+	// Check if update is needed
+	if !needsUpdate(version, latestVersion) {
+		fmt.Println("\nYou're already running the latest version!")
+		return nil
+	}
+
+	fmt.Println("\nDownloading and installing update...")
+
+	result := updater.CheckAndUpdate(ctx)
+	if result.Error != nil {
+		return fmt.Errorf("update failed: %w", result.Error)
+	}
+
+	if result.Updated {
+		fmt.Printf("\n\033[32m✓ Successfully updated from v%s to v%s\033[0m\n", result.FromVersion, result.ToVersion)
+		fmt.Println("  Restart the CLI to use the new version.")
+	}
+
+	return nil
+}
+
+func runUpdateCheck(cmd *cobra.Command, args []string) error {
+	fmt.Println("Checking for updates...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	updater := update.NewUpdater(version)
+	release, err := updater.GetLatestRelease(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	latestVersion := release.TagName
+	fmt.Printf("Current version: %s\n", version)
+	fmt.Printf("Latest version:  %s\n", latestVersion)
+
+	if needsUpdate(version, latestVersion) {
+		fmt.Printf("\n\033[33mA new version is available!\033[0m\n")
+		fmt.Println("Run 'canvas update' to install it.")
+	} else {
+		fmt.Println("\nYou're already running the latest version!")
+	}
+
+	return nil
+}
+
+func runUpdateEnable(cmd *cobra.Command, args []string) error {
+	interval, _ := cmd.Flags().GetInt("interval")
+	if interval < 1 {
+		interval = 60
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.Settings == nil {
+		cfg.Settings = config.DefaultSettings()
+	}
+
+	cfg.Settings.AutoUpdateEnabled = true
+	cfg.Settings.AutoUpdateIntervalMin = interval
+
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Printf("Auto-updates enabled (checking every %d minutes)\n", interval)
+	return nil
+}
+
+func runUpdateDisable(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.Settings == nil {
+		cfg.Settings = config.DefaultSettings()
+	}
+
+	cfg.Settings.AutoUpdateEnabled = false
+
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Println("Auto-updates disabled")
+	fmt.Println("Run 'canvas update enable' to re-enable automatic updates.")
+	return nil
+}
+
+func runUpdateStatus(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	fmt.Println("Auto-Update Status")
+	fmt.Println("==================")
+	fmt.Printf("Current version: %s\n", version)
+
+	if cfg.Settings != nil {
+		status := "disabled"
+		if cfg.Settings.AutoUpdateEnabled {
+			status = "enabled"
+		}
+		fmt.Printf("Auto-update: %s\n", status)
+		fmt.Printf("Check interval: %d minutes\n", cfg.Settings.AutoUpdateIntervalMin)
+	} else {
+		fmt.Println("Auto-update: enabled (default)")
+		fmt.Println("Check interval: 60 minutes (default)")
+	}
+
+	// Show last check info
+	stateManager, err := update.NewStateManager()
+	if err == nil {
+		state, err := stateManager.Load()
+		if err == nil && !state.LastCheckTime.IsZero() {
+			fmt.Printf("\nLast check: %s\n", state.LastCheckTime.Format(time.RFC3339))
+			if state.LastError != "" && !state.LastErrorTime.IsZero() {
+				fmt.Printf("Last error: %s (%s)\n", state.LastError, state.LastErrorTime.Format(time.RFC3339))
+			}
+		}
+	}
+
+	return nil
+}
+
+// needsUpdate compares versions to determine if an update is needed
+func needsUpdate(current, latest string) bool {
+	// Strip 'v' prefix for comparison
+	current = trimVersionPrefix(current)
+	latest = trimVersionPrefix(latest)
+
+	// Skip dev versions
+	if current == "dev" || current == "" {
+		return false
+	}
+
+	return current != latest
+}
+
+func trimVersionPrefix(v string) string {
+	if len(v) > 0 && v[0] == 'v' {
+		return v[1:]
+	}
+	return v
+}

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import "testing"
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		latest   string
+		current  string
+		expected bool
+	}{
+		{"newer major", "2.0.0", "1.0.0", true},
+		{"newer minor", "1.1.0", "1.0.0", true},
+		{"newer patch", "1.0.1", "1.0.0", true},
+		{"same version", "1.0.0", "1.0.0", false},
+		{"older major", "1.0.0", "2.0.0", false},
+		{"older minor", "1.0.0", "1.1.0", false},
+		{"older patch", "1.0.0", "1.0.1", false},
+		{"with v prefix latest", "v1.1.0", "1.0.0", true},
+		{"with v prefix current", "1.1.0", "v1.0.0", true},
+		{"with v prefix both", "v1.1.0", "v1.0.0", true},
+		{"with prerelease", "1.1.0-beta", "1.0.0", true},
+		{"dev version current", "1.1.0", "dev", false},
+		{"empty current", "1.1.0", "", false},
+		// Edge case: downgrade protection
+		{"downgrade protection major", "1.0.0", "2.0.0", false},
+		{"downgrade protection minor", "1.0.0", "1.1.0", false},
+		{"downgrade protection patch", "1.0.0", "1.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNewerVersion(tt.latest, tt.current)
+			if result != tt.expected {
+				t.Errorf("isNewerVersion(%q, %q) = %v, expected %v", tt.latest, tt.current, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected [3]int
+	}{
+		{"1.2.3", [3]int{1, 2, 3}},
+		{"v1.2.3", [3]int{1, 2, 3}},
+		{"1.2", [3]int{1, 2, 0}},
+		{"1", [3]int{1, 0, 0}},
+		{"1.2.3-beta", [3]int{1, 2, 3}},
+		{"1.2.3-rc.1", [3]int{1, 2, 3}},
+		{"0.0.0", [3]int{0, 0, 0}},
+		{"10.20.30", [3]int{10, 20, 30}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseVersion(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseVersion(%q) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,23 +62,27 @@ func (i *Instance) HasDefaultAccountID() bool {
 
 // Settings holds global application settings
 type Settings struct {
-	DefaultOutputFormat string  `yaml:"default_output_format"`
-	RequestsPerSecond   float64 `yaml:"requests_per_second"`
-	CacheEnabled        bool    `yaml:"cache_enabled"`
-	CacheTTL            int     `yaml:"cache_ttl_minutes"`
-	TelemetryEnabled    bool    `yaml:"telemetry_enabled"`
-	LogLevel            string  `yaml:"log_level"`
+	DefaultOutputFormat   string  `yaml:"default_output_format"`
+	RequestsPerSecond     float64 `yaml:"requests_per_second"`
+	CacheEnabled          bool    `yaml:"cache_enabled"`
+	CacheTTL              int     `yaml:"cache_ttl_minutes"`
+	TelemetryEnabled      bool    `yaml:"telemetry_enabled"`
+	LogLevel              string  `yaml:"log_level"`
+	AutoUpdateEnabled     bool    `yaml:"auto_update_enabled"`
+	AutoUpdateIntervalMin int     `yaml:"auto_update_interval_minutes"`
 }
 
 // DefaultSettings returns the default settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		DefaultOutputFormat: "table",
-		RequestsPerSecond:   5.0,
-		CacheEnabled:        true,
-		CacheTTL:            15,
-		TelemetryEnabled:    false,
-		LogLevel:            "info",
+		DefaultOutputFormat:   "table",
+		RequestsPerSecond:     5.0,
+		CacheEnabled:          true,
+		CacheTTL:              15,
+		TelemetryEnabled:      false,
+		LogLevel:              "info",
+		AutoUpdateEnabled:     true,
+		AutoUpdateIntervalMin: 60, // Check every hour
 	}
 }
 

--- a/internal/update/auto.go
+++ b/internal/update/auto.go
@@ -1,0 +1,109 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+// AutoUpdater handles automatic update checking and installation
+type AutoUpdater struct {
+	CurrentVersion string
+	CheckInterval  time.Duration
+	Enabled        bool
+
+	updater      *Updater
+	stateManager *StateManager
+}
+
+// NewAutoUpdater creates a new AutoUpdater
+func NewAutoUpdater(currentVersion string, enabled bool, checkInterval time.Duration) (*AutoUpdater, error) {
+	stateManager, err := NewStateManager()
+	if err != nil {
+		return nil, err
+	}
+
+	if checkInterval == 0 {
+		checkInterval = DefaultCheckInterval
+	}
+
+	return &AutoUpdater{
+		CurrentVersion: currentVersion,
+		CheckInterval:  checkInterval,
+		Enabled:        enabled,
+		updater:        NewUpdater(currentVersion),
+		stateManager:   stateManager,
+	}, nil
+}
+
+// RunUpdateCheck performs the update check and installation
+// This should be called at CLI startup
+// Returns messages to display to the user (if any)
+func (a *AutoUpdater) RunUpdateCheck(ctx context.Context) {
+	if !a.Enabled {
+		return
+	}
+
+	// Skip dev versions
+	if a.CurrentVersion == "dev" || a.CurrentVersion == "" {
+		return
+	}
+
+	// Check if we should perform a check
+	if !a.stateManager.ShouldCheck(a.CheckInterval) {
+		return
+	}
+
+	// Run update in background with timeout
+	updateCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	result := a.updater.CheckAndUpdate(updateCtx)
+
+	// Record the check (ignore error - update state is non-critical)
+	_ = a.stateManager.RecordCheck(result)
+}
+
+// RunUpdateCheckAsync runs the update check in a goroutine
+// This prevents blocking the main CLI execution
+func (a *AutoUpdater) RunUpdateCheckAsync(ctx context.Context) {
+	go func() {
+		// Recover from any panics to not crash the CLI
+		defer func() {
+			_ = recover() // Silently ignore panics in the updater
+		}()
+
+		a.RunUpdateCheck(ctx)
+	}()
+}
+
+// PrintNotifications prints any pending update notifications to stderr
+// This should be called after command execution
+func (a *AutoUpdater) PrintNotifications() {
+	// Check for successful update notification
+	if fromVersion, toVersion, hasNotification := a.stateManager.GetPendingNotification(); hasNotification {
+		fmt.Fprintf(os.Stderr, "\n\033[32m✓ Updated canvas-cli from v%s to v%s\033[0m\n", fromVersion, toVersion)
+		fmt.Fprintf(os.Stderr, "  Run 'canvas version' to verify the new version.\n")
+		return
+	}
+
+	// Check for error notification
+	if errMsg, hasError := a.stateManager.GetLastError(); hasError {
+		fmt.Fprintf(os.Stderr, "\n\033[33m⚠ Auto-update failed: %s\033[0m\n", errMsg)
+		fmt.Fprintf(os.Stderr, "  You can manually update with: go install github.com/jjuanrivvera/canvas-cli/cmd/canvas@latest\n")
+	}
+}
+
+// CheckNow performs an immediate update check, ignoring the interval
+// This is useful for manual update commands
+func (a *AutoUpdater) CheckNow(ctx context.Context) *UpdateResult {
+	result := a.updater.CheckAndUpdate(ctx)
+	_ = a.stateManager.RecordCheck(result) // Ignore error - state is non-critical
+	return result
+}
+
+// GetState returns the current update state
+func (a *AutoUpdater) GetState() (*State, error) {
+	return a.stateManager.Load()
+}

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -1,0 +1,146 @@
+package update
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// State tracks update-related state
+type State struct {
+	LastCheckTime    time.Time `json:"last_check_time"`
+	LastUpdateTime   time.Time `json:"last_update_time,omitempty"`
+	LastVersion      string    `json:"last_version,omitempty"`
+	UpdatedToVersion string    `json:"updated_to_version,omitempty"`
+	LastError        string    `json:"last_error,omitempty"`
+	LastErrorTime    time.Time `json:"last_error_time,omitempty"`
+}
+
+// StateManager handles loading and saving update state
+type StateManager struct {
+	statePath string
+}
+
+// NewStateManager creates a new StateManager
+func NewStateManager() (*StateManager, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	statePath := filepath.Join(home, ".canvas-cli", "update-state.json")
+	return &StateManager{statePath: statePath}, nil
+}
+
+// Load loads the update state from disk
+func (m *StateManager) Load() (*State, error) {
+	data, err := os.ReadFile(m.statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &State{}, nil
+		}
+		return nil, err
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		// If file is corrupted, return fresh state
+		return &State{}, nil
+	}
+
+	return &state, nil
+}
+
+// Save saves the update state to disk
+func (m *StateManager) Save(state *State) error {
+	// Ensure directory exists
+	dir := filepath.Dir(m.statePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(m.statePath, data, 0600)
+}
+
+// ShouldCheck returns true if enough time has passed since the last check
+func (m *StateManager) ShouldCheck(interval time.Duration) bool {
+	state, err := m.Load()
+	if err != nil {
+		return true // Check if we can't read state
+	}
+
+	return time.Since(state.LastCheckTime) >= interval
+}
+
+// RecordCheck records that an update check was performed
+func (m *StateManager) RecordCheck(result *UpdateResult) error {
+	state, _ := m.Load()
+
+	state.LastCheckTime = time.Now()
+
+	if result.Updated {
+		state.LastUpdateTime = time.Now()
+		state.LastVersion = result.FromVersion
+		state.UpdatedToVersion = result.ToVersion
+		state.LastError = ""
+		state.LastErrorTime = time.Time{}
+	}
+
+	if result.Error != nil {
+		state.LastError = result.Error.Error()
+		state.LastErrorTime = time.Now()
+	}
+
+	return m.Save(state)
+}
+
+// GetPendingNotification returns update info if there's a recent update to notify about
+// It clears the notification after returning it
+func (m *StateManager) GetPendingNotification() (fromVersion, toVersion string, hasNotification bool) {
+	state, err := m.Load()
+	if err != nil {
+		return "", "", false
+	}
+
+	// Check if there's a recent update (within last 5 minutes) to notify about
+	if state.UpdatedToVersion != "" && time.Since(state.LastUpdateTime) < 5*time.Minute {
+		fromVersion = state.LastVersion
+		toVersion = state.UpdatedToVersion
+
+		// Clear the notification (ignore save error - non-critical)
+		state.UpdatedToVersion = ""
+		_ = m.Save(state)
+
+		return fromVersion, toVersion, true
+	}
+
+	return "", "", false
+}
+
+// GetLastError returns the last error if it occurred recently
+func (m *StateManager) GetLastError() (string, bool) {
+	state, err := m.Load()
+	if err != nil {
+		return "", false
+	}
+
+	// Only report errors from the last 5 minutes
+	if state.LastError != "" && time.Since(state.LastErrorTime) < 5*time.Minute {
+		errorMsg := state.LastError
+
+		// Clear the error after reporting (ignore save error - non-critical)
+		state.LastError = ""
+		state.LastErrorTime = time.Time{}
+		_ = m.Save(state)
+
+		return errorMsg, true
+	}
+
+	return "", false
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,431 @@
+// Package update provides auto-update functionality for the CLI.
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	// GitHubOwner is the repository owner
+	GitHubOwner = "jjuanrivvera"
+	// GitHubRepo is the repository name
+	GitHubRepo = "canvas-cli"
+	// BinaryName is the name of the binary to update
+	BinaryName = "canvas"
+	// DefaultCheckInterval is the default interval between update checks
+	DefaultCheckInterval = 1 * time.Hour
+)
+
+// Release represents a GitHub release
+type Release struct {
+	TagName    string  `json:"tag_name"`
+	Name       string  `json:"name"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	Assets     []Asset `json:"assets"`
+	Body       string  `json:"body"`
+}
+
+// Asset represents a release asset
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+// UpdateResult contains the result of an update operation
+type UpdateResult struct {
+	Updated     bool
+	FromVersion string
+	ToVersion   string
+	Error       error
+}
+
+// Updater handles checking and applying updates
+type Updater struct {
+	CurrentVersion string
+	HTTPClient     *http.Client
+	// For testing - allows overriding the executable path
+	ExecutablePath string
+}
+
+// NewUpdater creates a new Updater instance
+func NewUpdater(currentVersion string) *Updater {
+	return &Updater{
+		CurrentVersion: currentVersion,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// CheckAndUpdate checks for updates and applies them if available
+func (u *Updater) CheckAndUpdate(ctx context.Context) *UpdateResult {
+	result := &UpdateResult{
+		FromVersion: u.CurrentVersion,
+	}
+
+	// Skip if running dev version
+	if u.CurrentVersion == "dev" || u.CurrentVersion == "" {
+		return result
+	}
+
+	// Get latest release
+	release, err := u.GetLatestRelease(ctx)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to check for updates: %w", err)
+		return result
+	}
+
+	// Compare versions
+	latestVersion := strings.TrimPrefix(release.TagName, "v")
+	currentVersion := strings.TrimPrefix(u.CurrentVersion, "v")
+
+	if !isNewerVersion(latestVersion, currentVersion) {
+		return result // No update needed
+	}
+
+	result.ToVersion = latestVersion
+
+	// Find the appropriate asset
+	asset, checksumAsset := u.findAssets(release)
+	if asset == nil {
+		result.Error = fmt.Errorf("no compatible binary found for %s/%s", runtime.GOOS, runtime.GOARCH)
+		return result
+	}
+
+	// Download the binary
+	binary, err := u.downloadAsset(ctx, asset)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to download update: %w", err)
+		return result
+	}
+
+	// Verify checksum if available
+	if checksumAsset != nil {
+		checksums, err := u.downloadChecksums(ctx, checksumAsset)
+		if err != nil {
+			result.Error = fmt.Errorf("failed to download checksums: %w", err)
+			return result
+		}
+
+		if !u.verifyChecksum(binary, asset.Name, checksums) {
+			result.Error = fmt.Errorf("checksum verification failed")
+			return result
+		}
+	}
+
+	// Extract binary from archive
+	extractedBinary, err := u.extractBinary(binary, asset.Name)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to extract binary: %w", err)
+		return result
+	}
+
+	// Apply the update
+	if err := u.applyUpdate(extractedBinary); err != nil {
+		result.Error = fmt.Errorf("failed to apply update: %w", err)
+		return result
+	}
+
+	result.Updated = true
+	return result
+}
+
+// GetLatestRelease fetches the latest release from GitHub
+func (u *Updater) GetLatestRelease(ctx context.Context) (*Release, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", GitHubOwner, GitHubRepo)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "canvas-cli-updater")
+
+	resp, err := u.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	return &release, nil
+}
+
+// findAssets finds the appropriate binary and checksum assets for the current platform
+func (u *Updater) findAssets(release *Release) (*Asset, *Asset) {
+	// Map GOARCH to archive naming convention
+	archName := runtime.GOARCH
+	if archName == "amd64" {
+		archName = "x86_64"
+	}
+
+	// Determine expected archive name pattern
+	// Format: canvas-cli_<os>_<arch>.tar.gz (or .zip for windows)
+	ext := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = ".zip"
+	}
+
+	expectedName := fmt.Sprintf("canvas-cli_%s_%s%s", runtime.GOOS, archName, ext)
+
+	var binaryAsset, checksumAsset *Asset
+
+	for i := range release.Assets {
+		asset := &release.Assets[i]
+		if asset.Name == expectedName {
+			binaryAsset = asset
+		}
+		if asset.Name == "checksums.txt" {
+			checksumAsset = asset
+		}
+	}
+
+	return binaryAsset, checksumAsset
+}
+
+// downloadAsset downloads a release asset
+func (u *Updater) downloadAsset(ctx context.Context, asset *Asset) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", asset.BrowserDownloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "canvas-cli-updater")
+
+	resp, err := u.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download asset: status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// downloadChecksums downloads and parses the checksums file
+func (u *Updater) downloadChecksums(ctx context.Context, asset *Asset) (map[string]string, error) {
+	data, err := u.downloadAsset(ctx, asset)
+	if err != nil {
+		return nil, err
+	}
+
+	checksums := make(map[string]string)
+	lines := strings.Split(string(data), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Format: <checksum>  <filename>
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			checksums[parts[1]] = parts[0]
+		}
+	}
+
+	return checksums, nil
+}
+
+// verifyChecksum verifies the downloaded binary against the checksum
+func (u *Updater) verifyChecksum(data []byte, filename string, checksums map[string]string) bool {
+	expectedHash, ok := checksums[filename]
+	if !ok {
+		return false
+	}
+
+	hash := sha256.Sum256(data)
+	actualHash := hex.EncodeToString(hash[:])
+
+	return strings.EqualFold(expectedHash, actualHash)
+}
+
+// extractBinary extracts the binary from the archive
+func (u *Updater) extractBinary(archive []byte, archiveName string) ([]byte, error) {
+	if strings.HasSuffix(archiveName, ".zip") {
+		return u.extractFromZip(archive)
+	}
+	return u.extractFromTarGz(archive)
+}
+
+// extractFromTarGz extracts the binary from a tar.gz archive
+func (u *Updater) extractFromTarGz(archive []byte) ([]byte, error) {
+	gzReader, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, err
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+
+	binaryName := BinaryName
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if this is the binary we're looking for
+		if filepath.Base(header.Name) == binaryName && header.Typeflag == tar.TypeReg {
+			return io.ReadAll(tarReader)
+		}
+	}
+
+	return nil, fmt.Errorf("binary %s not found in archive", binaryName)
+}
+
+// extractFromZip extracts the binary from a zip archive
+func (u *Updater) extractFromZip(archive []byte) ([]byte, error) {
+	zipReader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, err
+	}
+
+	binaryName := BinaryName
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+
+	for _, file := range zipReader.File {
+		if filepath.Base(file.Name) == binaryName {
+			rc, err := file.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+
+	return nil, fmt.Errorf("binary %s not found in archive", binaryName)
+}
+
+// applyUpdate replaces the current binary with the new one
+func (u *Updater) applyUpdate(newBinary []byte) error {
+	execPath := u.ExecutablePath
+	if execPath == "" {
+		var err error
+		execPath, err = os.Executable()
+		if err != nil {
+			return fmt.Errorf("failed to get executable path: %w", err)
+		}
+
+		// Resolve symlinks to get the actual binary path
+		execPath, err = filepath.EvalSymlinks(execPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve executable path: %w", err)
+		}
+	}
+
+	// Create a temporary file in the same directory (for atomic rename)
+	execDir := filepath.Dir(execPath)
+	tmpFile, err := os.CreateTemp(execDir, "canvas-update-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	// Write the new binary
+	if _, err := tmpFile.Write(newBinary); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to write new binary: %w", err)
+	}
+	tmpFile.Close()
+
+	// Make it executable
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to set permissions: %w", err)
+	}
+
+	// Backup the old binary
+	backupPath := execPath + ".bak"
+	if err := os.Rename(execPath, backupPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to backup old binary: %w", err)
+	}
+
+	// Move new binary into place
+	if err := os.Rename(tmpPath, execPath); err != nil {
+		// Try to restore the backup (ignore restore error - best effort)
+		_ = os.Rename(backupPath, execPath)
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to install new binary: %w", err)
+	}
+
+	// Remove backup
+	os.Remove(backupPath)
+
+	return nil
+}
+
+// isNewerVersion compares two semver versions
+// Returns true if latest is newer than current
+func isNewerVersion(latest, current string) bool {
+	latestParts := parseVersion(latest)
+	currentParts := parseVersion(current)
+
+	for i := 0; i < 3; i++ {
+		if latestParts[i] > currentParts[i] {
+			return true
+		}
+		if latestParts[i] < currentParts[i] {
+			return false
+		}
+	}
+
+	return false
+}
+
+// parseVersion parses a semver string into [major, minor, patch]
+func parseVersion(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.Split(v, ".")
+
+	var result [3]int
+	for i := 0; i < 3 && i < len(parts); i++ {
+		// Strip any pre-release suffix
+		numStr := strings.Split(parts[i], "-")[0]
+		fmt.Sscanf(numStr, "%d", &result[i])
+	}
+
+	return result
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,273 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		latest   string
+		current  string
+		expected bool
+	}{
+		{"newer major", "2.0.0", "1.0.0", true},
+		{"newer minor", "1.1.0", "1.0.0", true},
+		{"newer patch", "1.0.1", "1.0.0", true},
+		{"same version", "1.0.0", "1.0.0", false},
+		{"older major", "1.0.0", "2.0.0", false},
+		{"older minor", "1.0.0", "1.1.0", false},
+		{"older patch", "1.0.0", "1.0.1", false},
+		{"with v prefix", "v1.1.0", "v1.0.0", true},
+		{"mixed prefix", "1.1.0", "v1.0.0", true},
+		{"with prerelease", "1.1.0-beta", "1.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNewerVersion(tt.latest, tt.current)
+			if result != tt.expected {
+				t.Errorf("isNewerVersion(%q, %q) = %v, expected %v", tt.latest, tt.current, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected [3]int
+	}{
+		{"1.2.3", [3]int{1, 2, 3}},
+		{"v1.2.3", [3]int{1, 2, 3}},
+		{"1.2", [3]int{1, 2, 0}},
+		{"1", [3]int{1, 0, 0}},
+		{"1.2.3-beta", [3]int{1, 2, 3}},
+		{"1.2.3-rc.1", [3]int{1, 2, 3}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseVersion(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseVersion(%q) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetLatestRelease(t *testing.T) {
+	// Create a mock server
+	release := Release{
+		TagName:    "v1.2.3",
+		Name:       "v1.2.3",
+		Draft:      false,
+		Prerelease: false,
+		Assets: []Asset{
+			{
+				Name:               "canvas-cli_darwin_x86_64.tar.gz",
+				BrowserDownloadURL: "https://example.com/canvas-cli_darwin_x86_64.tar.gz",
+			},
+			{
+				Name:               "checksums.txt",
+				BrowserDownloadURL: "https://example.com/checksums.txt",
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer server.Close()
+
+	// Create updater with custom HTTP client pointing to mock server
+	updater := NewUpdater("1.0.0")
+	updater.HTTPClient = server.Client()
+
+	// Override the URL by using a custom transport
+	originalURL := server.URL
+	updater.HTTPClient.Transport = &urlRewriteTransport{
+		targetURL: originalURL,
+	}
+
+	ctx := context.Background()
+	result, err := updater.GetLatestRelease(ctx)
+	if err != nil {
+		t.Fatalf("GetLatestRelease failed: %v", err)
+	}
+
+	if result.TagName != "v1.2.3" {
+		t.Errorf("Expected tag v1.2.3, got %s", result.TagName)
+	}
+}
+
+// urlRewriteTransport rewrites requests to the test server
+type urlRewriteTransport struct {
+	targetURL string
+}
+
+func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = t.targetURL[7:] // Remove "http://"
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestFindAssets(t *testing.T) {
+	release := &Release{
+		Assets: []Asset{
+			{Name: "canvas-cli_darwin_x86_64.tar.gz", BrowserDownloadURL: "https://example.com/darwin_amd64.tar.gz"},
+			{Name: "canvas-cli_darwin_arm64.tar.gz", BrowserDownloadURL: "https://example.com/darwin_arm64.tar.gz"},
+			{Name: "canvas-cli_linux_x86_64.tar.gz", BrowserDownloadURL: "https://example.com/linux_amd64.tar.gz"},
+			{Name: "canvas-cli_windows_x86_64.zip", BrowserDownloadURL: "https://example.com/windows_amd64.zip"},
+			{Name: "checksums.txt", BrowserDownloadURL: "https://example.com/checksums.txt"},
+		},
+	}
+
+	updater := NewUpdater("1.0.0")
+	binaryAsset, checksumAsset := updater.findAssets(release)
+
+	if checksumAsset == nil {
+		t.Error("Expected to find checksum asset")
+	}
+	if checksumAsset != nil && checksumAsset.Name != "checksums.txt" {
+		t.Errorf("Expected checksums.txt, got %s", checksumAsset.Name)
+	}
+
+	// Binary asset depends on current OS/arch
+	if binaryAsset != nil {
+		t.Logf("Found binary asset for %s/%s: %s", runtime.GOOS, runtime.GOARCH, binaryAsset.Name)
+	}
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	testData := []byte("test binary content")
+	hash := sha256.Sum256(testData)
+	expectedHash := hex.EncodeToString(hash[:])
+
+	checksums := map[string]string{
+		"test.tar.gz": expectedHash,
+	}
+
+	updater := NewUpdater("1.0.0")
+
+	// Valid checksum
+	if !updater.verifyChecksum(testData, "test.tar.gz", checksums) {
+		t.Error("Expected checksum verification to pass")
+	}
+
+	// Wrong file
+	if updater.verifyChecksum(testData, "other.tar.gz", checksums) {
+		t.Error("Expected checksum verification to fail for unknown file")
+	}
+
+	// Wrong data
+	if updater.verifyChecksum([]byte("wrong data"), "test.tar.gz", checksums) {
+		t.Error("Expected checksum verification to fail for wrong data")
+	}
+}
+
+func TestExtractFromTarGz(t *testing.T) {
+	// Create a test tar.gz archive
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	binaryName := "canvas"
+	if runtime.GOOS == "windows" {
+		binaryName = "canvas.exe"
+	}
+
+	// Add the binary file
+	binaryContent := []byte("#!/bin/bash\necho hello")
+	hdr := &tar.Header{
+		Name: binaryName,
+		Mode: 0755,
+		Size: int64(len(binaryContent)),
+	}
+	if err := tarWriter.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write(binaryContent); err != nil {
+		t.Fatal(err)
+	}
+
+	tarWriter.Close()
+	gzWriter.Close()
+
+	updater := NewUpdater("1.0.0")
+	extracted, err := updater.extractFromTarGz(buf.Bytes())
+	if err != nil {
+		t.Fatalf("extractFromTarGz failed: %v", err)
+	}
+
+	if !bytes.Equal(extracted, binaryContent) {
+		t.Error("Extracted content doesn't match original")
+	}
+}
+
+func TestApplyUpdate(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "update-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create a fake "current" binary
+	currentBinary := filepath.Join(tmpDir, "canvas")
+	if err := os.WriteFile(currentBinary, []byte("old version"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// New binary content
+	newContent := []byte("new version")
+
+	updater := NewUpdater("1.0.0")
+	updater.ExecutablePath = currentBinary
+
+	if err := updater.applyUpdate(newContent); err != nil {
+		t.Fatalf("applyUpdate failed: %v", err)
+	}
+
+	// Verify the new content
+	content, err := os.ReadFile(currentBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(content, newContent) {
+		t.Errorf("Expected new content, got: %s", content)
+	}
+
+	// Verify backup was removed
+	if _, err := os.Stat(currentBinary + ".bak"); !os.IsNotExist(err) {
+		t.Error("Backup file should have been removed")
+	}
+}
+
+func TestCheckAndUpdateSkipsDevVersion(t *testing.T) {
+	updater := NewUpdater("dev")
+
+	ctx := context.Background()
+	result := updater.CheckAndUpdate(ctx)
+
+	if result.Updated {
+		t.Error("Should not update dev version")
+	}
+	if result.Error != nil {
+		t.Errorf("Should not error for dev version: %v", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds automatic update checking and installation on every CLI run
- Downloads and installs new versions from GitHub releases automatically
- Notifies users when updates succeed or fail
- Provides manual control via `canvas update` commands

## Features

### Auto-Update Behavior
- Checks for updates asynchronously on every CLI invocation (doesn't block commands)
- Respects configurable check interval (default: 1 hour)
- Downloads platform-specific binary from GitHub releases
- Verifies SHA256 checksum before installation
- Atomically replaces binary with backup/restore on failure
- Prints notification after command completes:
  - `✓ Updated canvas-cli from v1.5.0 to v1.6.1`
  - `⚠ Auto-update failed: <error>`

### Manual Commands
```bash
canvas update              # Check and install updates now
canvas update check        # Check for updates without installing
canvas update enable       # Enable auto-updates
canvas update disable      # Disable auto-updates
canvas update status       # Show auto-update status
```

### Configuration
New settings in config:
- `auto_update_enabled` (default: `true`)
- `auto_update_interval_minutes` (default: `60`)

## Test plan

- [x] Unit tests for version comparison
- [x] Unit tests for checksum verification
- [x] Unit tests for tar.gz/zip extraction
- [x] Unit tests for binary replacement
- [x] Manual test: `canvas update check` fetches latest release
- [x] Manual test: `canvas update status` shows configuration
- [ ] Manual test: Full update cycle (requires older version installed)