### PR TITLE
feat: add CLI UX improvements (aliases, filtering, context, dry-run)

### DIFF
--- a/cmd/canvas/main.go
+++ b/cmd/canvas/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jjuanrivvera/canvas-cli/commands"
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
 )
 
 var (
@@ -17,8 +19,88 @@ var (
 )
 
 func main() {
+	// Expand aliases before executing commands
+	expandAliases()
+
 	if err := commands.Execute(Version, Commit, BuildDate); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// expandAliases checks if the first argument is an alias and expands it
+func expandAliases() {
+	if len(os.Args) < 2 {
+		return
+	}
+
+	// Skip if first arg is a flag
+	if strings.HasPrefix(os.Args[1], "-") {
+		return
+	}
+
+	// Load config to get aliases
+	cfg, err := config.Load()
+	if err != nil {
+		return // Silently ignore config errors
+	}
+
+	// Check if first arg is an alias
+	firstArg := os.Args[1]
+	expansion, exists := cfg.GetAlias(firstArg)
+	if !exists {
+		return
+	}
+
+	// Parse the expansion into args
+	expandedArgs := parseAliasExpansion(expansion)
+	if len(expandedArgs) == 0 {
+		return
+	}
+
+	// Replace the alias with expanded args
+	// os.Args[0] is the program name, os.Args[1] is the alias
+	// os.Args[2:] are any additional args passed after the alias
+	newArgs := make([]string, 0, len(os.Args)+len(expandedArgs))
+	newArgs = append(newArgs, os.Args[0])
+	newArgs = append(newArgs, expandedArgs...)
+	newArgs = append(newArgs, os.Args[2:]...)
+	os.Args = newArgs
+}
+
+// parseAliasExpansion splits an alias expansion into arguments
+// Handles quoted strings properly
+func parseAliasExpansion(expansion string) []string {
+	var args []string
+	var current strings.Builder
+	inQuote := false
+	quoteChar := rune(0)
+
+	for _, r := range expansion {
+		switch {
+		case r == '"' || r == '\'':
+			if inQuote && r == quoteChar {
+				inQuote = false
+				quoteChar = 0
+			} else if !inQuote {
+				inQuote = true
+				quoteChar = r
+			} else {
+				current.WriteRune(r)
+			}
+		case r == ' ' && !inQuote:
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+
+	return args
 }

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -1,0 +1,185 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
+)
+
+func init() {
+	rootCmd.AddCommand(newAliasCmd())
+}
+
+func newAliasCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alias",
+		Short: "Manage command aliases",
+		Long: `Create, list, and delete custom command aliases.
+
+Aliases allow you to create shortcuts for frequently used commands.
+They can include flags and arguments.
+
+Examples:
+  # Create an alias
+  canvas alias set ca "assignments list --course-id 123"
+  
+  # Use the alias
+  canvas ca
+  
+  # Create an alias with multiple flags
+  canvas alias set ungraded "assignments list --course-id 123 --bucket ungraded"
+  
+  # List all aliases
+  canvas alias list
+  
+  # Delete an alias
+  canvas alias delete ca`,
+	}
+
+	cmd.AddCommand(newAliasSetCmd())
+	cmd.AddCommand(newAliasListCmd())
+	cmd.AddCommand(newAliasDeleteCmd())
+
+	return cmd
+}
+
+func newAliasSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <name> <expansion>",
+		Short: "Create or update an alias",
+		Long: `Create or update a command alias.
+
+The alias name should be a single word. The expansion is the command
+that will be executed when the alias is used.
+
+Examples:
+  canvas alias set ca "assignments list --course-id 123"
+  canvas alias set myc "courses list --enrollment-type teacher"
+  canvas alias set grade "submissions bulk-grade --csv"`,
+		Args: cobra.ExactArgs(2),
+		RunE: runAliasSet,
+	}
+
+	return cmd
+}
+
+func runAliasSet(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	expansion := args[1]
+
+	// Validate alias name (no spaces, not a built-in command)
+	if strings.Contains(name, " ") {
+		return fmt.Errorf("alias name cannot contain spaces")
+	}
+
+	// Check if it conflicts with a built-in command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == name || containsString(c.Aliases, name) {
+			return fmt.Errorf("cannot create alias %q: conflicts with built-in command", name)
+		}
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if err := cfg.SetAlias(name, expansion); err != nil {
+		return fmt.Errorf("failed to save alias: %w", err)
+	}
+
+	fmt.Printf("Alias %q set to: %s\n", name, expansion)
+	return nil
+}
+
+func newAliasListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all aliases",
+		Long:  `Display all configured command aliases.`,
+		Args:  cobra.NoArgs,
+		RunE:  runAliasList,
+	}
+
+	return cmd
+}
+
+func runAliasList(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	aliases := cfg.ListAliases()
+	if len(aliases) == 0 {
+		fmt.Println("No aliases configured.")
+		fmt.Println("\nCreate one with: canvas alias set <name> <command>")
+		return nil
+	}
+
+	// Sort aliases by name for consistent output
+	names := make([]string, 0, len(aliases))
+	for name := range aliases {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Build output data
+	type aliasEntry struct {
+		Name      string `json:"name"`
+		Expansion string `json:"expansion"`
+	}
+
+	data := make([]aliasEntry, 0, len(aliases))
+	for _, name := range names {
+		data = append(data, aliasEntry{
+			Name:      name,
+			Expansion: aliases[name],
+		})
+	}
+
+	return formatOutput(data, nil)
+}
+
+func newAliasDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <name>",
+		Aliases: []string{"rm", "remove"},
+		Short:   "Delete an alias",
+		Long:    `Remove a command alias.`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    runAliasDelete,
+	}
+
+	return cmd
+}
+
+func runAliasDelete(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if err := cfg.DeleteAlias(name); err != nil {
+		return err
+	}
+
+	fmt.Printf("Alias %q deleted.\n", name)
+	return nil
+}
+
+// containsString checks if a slice contains a string
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/commands/confirm.go
+++ b/commands/confirm.go
@@ -10,7 +10,15 @@ import (
 // confirmDelete prompts the user for confirmation before a destructive operation.
 // Returns true if the user confirms, false otherwise.
 // If force is true, skips the prompt and returns true.
+// If dryRun is true (global flag), shows what would be deleted and returns false.
 func confirmDelete(resourceType string, resourceID interface{}, force bool) (bool, error) {
+	// In dry-run mode, show what would be deleted but don't proceed
+	if dryRun {
+		fmt.Printf("DRY RUN: Would delete %s %v\n", resourceType, resourceID)
+		fmt.Println("No changes were made.")
+		return false, nil
+	}
+
 	if force {
 		return true, nil
 	}
@@ -24,4 +32,61 @@ func confirmDelete(resourceType string, resourceID interface{}, force bool) (boo
 
 	response = strings.TrimSpace(strings.ToLower(response))
 	return response == "y" || response == "yes", nil
+}
+
+// confirmDeleteWithDetails prompts for confirmation and shows resource details.
+// This provides a preview of what will be deleted.
+func confirmDeleteWithDetails(resourceType string, resourceID interface{}, details map[string]interface{}, force bool) (bool, error) {
+	// In dry-run mode, show detailed preview
+	if dryRun {
+		fmt.Printf("DRY RUN: Would delete %s %v\n", resourceType, resourceID)
+		if len(details) > 0 {
+			fmt.Println("Resource details:")
+			for key, value := range details {
+				fmt.Printf("  %s: %v\n", key, value)
+			}
+		}
+		fmt.Println("\nNo changes were made.")
+		return false, nil
+	}
+
+	// Show details before asking for confirmation
+	if len(details) > 0 && !force {
+		fmt.Printf("About to delete %s %v:\n", resourceType, resourceID)
+		for key, value := range details {
+			fmt.Printf("  %s: %v\n", key, value)
+		}
+		fmt.Println()
+	}
+
+	if force {
+		return true, nil
+	}
+
+	fmt.Print("Are you sure you want to delete this? [y/N]: ")
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes", nil
+}
+
+// confirmUpdate shows what will be changed in dry-run mode
+func confirmUpdateDryRun(resourceType string, resourceID interface{}, changes map[string]interface{}) bool {
+	if !dryRun {
+		return false
+	}
+
+	fmt.Printf("DRY RUN: Would update %s %v\n", resourceType, resourceID)
+	if len(changes) > 0 {
+		fmt.Println("Changes:")
+		for key, value := range changes {
+			fmt.Printf("  %s: %v\n", key, value)
+		}
+	}
+	fmt.Println("\nNo changes were made.")
+	return true
 }

--- a/commands/context.go
+++ b/commands/context.go
@@ -1,0 +1,271 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
+)
+
+func init() {
+	rootCmd.AddCommand(newContextCmd())
+}
+
+func newContextCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Manage working context (course, assignment, user IDs)",
+		Long: `Manage the current working context for Canvas CLI.
+
+Context allows you to set default values for course_id, assignment_id, user_id,
+and account_id that will be used automatically when those flags are not provided.
+
+Examples:
+  # Set the current course
+  canvas context set course 123
+
+  # Set multiple context values
+  canvas context set course 123
+  canvas context set assignment 456
+
+  # Now commands automatically use context
+  canvas assignments list  # uses course_id 123
+  canvas submissions list  # uses course_id 123 and assignment_id 456
+
+  # Show current context
+  canvas context show
+
+  # Clear all context
+  canvas context clear
+
+  # Clear specific context value
+  canvas context clear course`,
+	}
+
+	cmd.AddCommand(newContextSetCmd())
+	cmd.AddCommand(newContextShowCmd())
+	cmd.AddCommand(newContextClearCmd())
+
+	return cmd
+}
+
+func newContextSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <type> <id>",
+		Short: "Set a context value",
+		Long: `Set a context value that will be used as default for commands.
+
+Valid types:
+  course      - Course ID (used for --course-id)
+  assignment  - Assignment ID (used for --assignment-id)
+  user        - User ID (used for --user-id)
+  account     - Account ID (used for --account-id)
+
+Examples:
+  canvas context set course 123
+  canvas context set assignment 456`,
+		Args: cobra.ExactArgs(2),
+		RunE: runContextSet,
+	}
+
+	return cmd
+}
+
+func runContextSet(cmd *cobra.Command, args []string) error {
+	contextType := args[0]
+	idStr := args[1]
+
+	var id int64
+	if _, err := fmt.Sscanf(idStr, "%d", &id); err != nil {
+		return fmt.Errorf("invalid ID %q: must be a number", idStr)
+	}
+
+	if id <= 0 {
+		return fmt.Errorf("invalid ID %d: must be a positive number", id)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	ctx := cfg.GetContext()
+
+	switch contextType {
+	case "course", "course_id", "course-id":
+		ctx.CourseID = id
+		contextType = "course"
+	case "assignment", "assignment_id", "assignment-id":
+		ctx.AssignmentID = id
+		contextType = "assignment"
+	case "user", "user_id", "user-id":
+		ctx.UserID = id
+		contextType = "user"
+	case "account", "account_id", "account-id":
+		ctx.AccountID = id
+		contextType = "account"
+	default:
+		return fmt.Errorf("unknown context type %q. Valid types: course, assignment, user, account", contextType)
+	}
+
+	if err := cfg.SetContext(ctx); err != nil {
+		return fmt.Errorf("failed to save context: %w", err)
+	}
+
+	fmt.Printf("Context %s set to %d\n", contextType, id)
+	return nil
+}
+
+func newContextShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show current context",
+		Long:  `Display the current working context values.`,
+		Args:  cobra.NoArgs,
+		RunE:  runContextShow,
+	}
+
+	return cmd
+}
+
+func runContextShow(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	ctx := cfg.GetContext()
+
+	// Check if any context is set
+	if ctx.CourseID == 0 && ctx.AssignmentID == 0 && ctx.UserID == 0 && ctx.AccountID == 0 {
+		fmt.Println("No context set.")
+		fmt.Println("\nSet context with: canvas context set <type> <id>")
+		fmt.Println("Valid types: course, assignment, user, account")
+		return nil
+	}
+
+	fmt.Println("Current context:")
+	if ctx.CourseID > 0 {
+		fmt.Printf("  course_id:     %d\n", ctx.CourseID)
+	}
+	if ctx.AssignmentID > 0 {
+		fmt.Printf("  assignment_id: %d\n", ctx.AssignmentID)
+	}
+	if ctx.UserID > 0 {
+		fmt.Printf("  user_id:       %d\n", ctx.UserID)
+	}
+	if ctx.AccountID > 0 {
+		fmt.Printf("  account_id:    %d\n", ctx.AccountID)
+	}
+
+	return nil
+}
+
+func newContextClearCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear [type]",
+		Short: "Clear context values",
+		Long: `Clear all context values or a specific context type.
+
+Examples:
+  canvas context clear           # Clear all context
+  canvas context clear course    # Clear only course context`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runContextClear,
+	}
+
+	return cmd
+}
+
+func runContextClear(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if len(args) == 0 {
+		// Clear all context
+		if err := cfg.ClearContext(); err != nil {
+			return fmt.Errorf("failed to clear context: %w", err)
+		}
+		fmt.Println("Context cleared.")
+		return nil
+	}
+
+	// Clear specific context type
+	contextType := args[0]
+	ctx := cfg.GetContext()
+
+	switch contextType {
+	case "course", "course_id", "course-id":
+		ctx.CourseID = 0
+		contextType = "course"
+	case "assignment", "assignment_id", "assignment-id":
+		ctx.AssignmentID = 0
+		contextType = "assignment"
+	case "user", "user_id", "user-id":
+		ctx.UserID = 0
+		contextType = "user"
+	case "account", "account_id", "account-id":
+		ctx.AccountID = 0
+		contextType = "account"
+	default:
+		return fmt.Errorf("unknown context type %q. Valid types: course, assignment, user, account", contextType)
+	}
+
+	if err := cfg.SetContext(ctx); err != nil {
+		return fmt.Errorf("failed to save context: %w", err)
+	}
+
+	fmt.Printf("Context %s cleared.\n", contextType)
+	return nil
+}
+
+// GetContextCourseID returns the course ID from context if set and flag is not provided
+func GetContextCourseID(flagValue int64) int64 {
+	if flagValue != 0 {
+		return flagValue
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return 0
+	}
+	return cfg.GetContext().CourseID
+}
+
+// GetContextAssignmentID returns the assignment ID from context if set and flag is not provided
+func GetContextAssignmentID(flagValue int64) int64 {
+	if flagValue != 0 {
+		return flagValue
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return 0
+	}
+	return cfg.GetContext().AssignmentID
+}
+
+// GetContextUserID returns the user ID from context if set and flag is not provided
+func GetContextUserID(flagValue int64) int64 {
+	if flagValue != 0 {
+		return flagValue
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return 0
+	}
+	return cfg.GetContext().UserID
+}
+
+// GetContextAccountID returns the account ID from context if set and flag is not provided
+func GetContextAccountID(flagValue int64) int64 {
+	if flagValue != 0 {
+		return flagValue
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return 0
+	}
+	return cfg.GetContext().AccountID
+}

--- a/commands/filtering.go
+++ b/commands/filtering.go
@@ -1,0 +1,254 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// applyFiltering applies filter, columns, and sort operations to data
+// Returns the filtered/sorted data
+func applyFiltering(data interface{}) interface{} {
+	// Only apply to slices
+	v := reflect.ValueOf(data)
+	if v.Kind() != reflect.Slice {
+		return data
+	}
+
+	if v.Len() == 0 {
+		return data
+	}
+
+	// Convert to []map[string]interface{} for easier manipulation
+	items := toMapSlice(data)
+	if items == nil {
+		return data
+	}
+
+	// Apply text filter
+	if filterText != "" {
+		items = filterByText(items, filterText)
+	}
+
+	// Apply sorting
+	if sortField != "" {
+		items = sortByField(items, sortField)
+	}
+
+	// Apply column selection
+	if len(filterColumns) > 0 {
+		items = selectColumns(items, filterColumns)
+	}
+
+	return items
+}
+
+// toMapSlice converts a slice of structs to []map[string]interface{}
+func toMapSlice(data interface{}) []map[string]interface{} {
+	v := reflect.ValueOf(data)
+	if v.Kind() != reflect.Slice {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		item := v.Index(i).Interface()
+		m := structToMap(item)
+		if m != nil {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// structToMap converts a struct to map[string]interface{}
+func structToMap(data interface{}) map[string]interface{} {
+	// Handle if already a map
+	if m, ok := data.(map[string]interface{}); ok {
+		return m
+	}
+
+	// Use JSON as intermediate format for conversion
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+// filterByText filters items that contain the text in any field
+func filterByText(items []map[string]interface{}, text string) []map[string]interface{} {
+	text = strings.ToLower(text)
+	result := make([]map[string]interface{}, 0)
+
+	for _, item := range items {
+		if itemContainsText(item, text) {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// itemContainsText checks if any field in the item contains the text
+func itemContainsText(item map[string]interface{}, text string) bool {
+	for _, value := range item {
+		if value == nil {
+			continue
+		}
+		strVal := strings.ToLower(toString(value))
+		if strings.Contains(strVal, text) {
+			return true
+		}
+	}
+	return false
+}
+
+// toString converts a value to string for searching
+func toString(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		// Format as integer if it's a whole number
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		return fmt.Sprintf("%t", val)
+	case nil:
+		return ""
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return string(b)
+	}
+}
+
+// sortByField sorts items by a field name
+// Prefix with - for descending order
+func sortByField(items []map[string]interface{}, field string) []map[string]interface{} {
+	descending := false
+	if strings.HasPrefix(field, "-") {
+		descending = true
+		field = field[1:]
+	}
+
+	// Convert field name to match JSON naming (usually lowercase)
+	field = strings.ToLower(field)
+	fieldVariants := []string{field, strings.ReplaceAll(field, "_", ""), strings.ReplaceAll(field, "-", "_")}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		var vi, vj interface{}
+		for _, f := range fieldVariants {
+			if v, ok := items[i][f]; ok {
+				vi = v
+				break
+			}
+		}
+		for _, f := range fieldVariants {
+			if v, ok := items[j][f]; ok {
+				vj = v
+				break
+			}
+		}
+
+		result := compareValues(vi, vj)
+		if descending {
+			return result > 0
+		}
+		return result < 0
+	})
+
+	return items
+}
+
+// compareValues compares two interface values
+func compareValues(a, b interface{}) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	// Try numeric comparison
+	if na, ok := toFloat64(a); ok {
+		if nb, ok := toFloat64(b); ok {
+			if na < nb {
+				return -1
+			}
+			if na > nb {
+				return 1
+			}
+			return 0
+		}
+	}
+
+	// Fall back to string comparison
+	sa := strings.ToLower(toString(a))
+	sb := strings.ToLower(toString(b))
+	return strings.Compare(sa, sb)
+}
+
+// toFloat64 attempts to convert a value to float64
+func toFloat64(v interface{}) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case int32:
+		return float64(val), true
+	default:
+		return 0, false
+	}
+}
+
+// selectColumns filters items to only include specified columns
+func selectColumns(items []map[string]interface{}, columns []string) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(items))
+
+	// Normalize column names
+	normalizedCols := make([]string, len(columns))
+	for i, col := range columns {
+		normalizedCols[i] = strings.ToLower(strings.TrimSpace(col))
+	}
+
+	for i, item := range items {
+		filtered := make(map[string]interface{})
+		for key, value := range item {
+			keyLower := strings.ToLower(key)
+			for _, col := range normalizedCols {
+				if keyLower == col || strings.ReplaceAll(keyLower, "_", "") == strings.ReplaceAll(col, "_", "") {
+					filtered[key] = value
+					break
+				}
+			}
+		}
+		result[i] = filtered
+	}
+
+	return result
+}
+
+// hasFilteringOptions returns true if any filtering options are set
+func hasFilteringOptions() bool {
+	return filterText != "" || len(filterColumns) > 0 || sortField != ""
+}

--- a/commands/filtering_test.go
+++ b/commands/filtering_test.go
@@ -1,0 +1,455 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "string value",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "integer as float64",
+			input:    float64(123),
+			expected: "123",
+		},
+		{
+			name:     "decimal float64",
+			input:    float64(123.45),
+			expected: "123.45",
+		},
+		{
+			name:     "boolean true",
+			input:    true,
+			expected: "true",
+		},
+		{
+			name:     "boolean false",
+			input:    false,
+			expected: "false",
+		},
+		{
+			name:     "nil value",
+			input:    nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toString(tt.input)
+			if result != tt.expected {
+				t.Errorf("toString(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStructToMap(t *testing.T) {
+	type testStruct struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	input := testStruct{Name: "test", Value: 42}
+	result := structToMap(input)
+
+	if result == nil {
+		t.Fatal("structToMap() returned nil")
+	}
+
+	if result["name"] != "test" {
+		t.Errorf("structToMap().name = %v, want test", result["name"])
+	}
+
+	// JSON numbers are float64
+	if result["value"] != float64(42) {
+		t.Errorf("structToMap().value = %v, want 42", result["value"])
+	}
+}
+
+func TestStructToMap_AlreadyMap(t *testing.T) {
+	input := map[string]interface{}{"name": "test", "value": 42}
+	result := structToMap(input)
+
+	if !reflect.DeepEqual(result, input) {
+		t.Errorf("structToMap() = %v, want %v", result, input)
+	}
+}
+
+func TestToMapSlice(t *testing.T) {
+	type testStruct struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	input := []testStruct{
+		{ID: 1, Name: "first"},
+		{ID: 2, Name: "second"},
+	}
+
+	result := toMapSlice(input)
+
+	if len(result) != 2 {
+		t.Fatalf("toMapSlice() len = %d, want 2", len(result))
+	}
+
+	if result[0]["name"] != "first" {
+		t.Errorf("toMapSlice()[0].name = %v, want first", result[0]["name"])
+	}
+
+	if result[1]["name"] != "second" {
+		t.Errorf("toMapSlice()[1].name = %v, want second", result[1]["name"])
+	}
+}
+
+func TestToMapSlice_NonSlice(t *testing.T) {
+	result := toMapSlice("not a slice")
+
+	if result != nil {
+		t.Errorf("toMapSlice(non-slice) = %v, want nil", result)
+	}
+}
+
+func TestFilterByText(t *testing.T) {
+	items := []map[string]interface{}{
+		{"name": "Alice", "email": "alice@example.com"},
+		{"name": "Bob", "email": "bob@example.com"},
+		{"name": "Charlie", "email": "charlie@test.com"},
+	}
+
+	tests := []struct {
+		name     string
+		text     string
+		expected int
+	}{
+		{
+			name:     "filter by name",
+			text:     "alice",
+			expected: 1,
+		},
+		{
+			name:     "filter by email domain",
+			text:     "example.com",
+			expected: 2,
+		},
+		{
+			name:     "no match",
+			text:     "xyz",
+			expected: 0,
+		},
+		{
+			name:     "case insensitive",
+			text:     "ALICE",
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterByText(items, tt.text)
+			if len(result) != tt.expected {
+				t.Errorf("filterByText() len = %d, want %d", len(result), tt.expected)
+			}
+		})
+	}
+}
+
+func TestItemContainsText(t *testing.T) {
+	item := map[string]interface{}{
+		"name":  "Alice",
+		"id":    float64(123),
+		"email": nil,
+	}
+
+	tests := []struct {
+		name     string
+		text     string
+		expected bool
+	}{
+		{
+			name:     "contains in string field",
+			text:     "alice",
+			expected: true,
+		},
+		{
+			name:     "contains in numeric field",
+			text:     "123",
+			expected: true,
+		},
+		{
+			name:     "does not contain",
+			text:     "xyz",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := itemContainsText(item, tt.text)
+			if result != tt.expected {
+				t.Errorf("itemContainsText() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSortByField(t *testing.T) {
+	items := []map[string]interface{}{
+		{"name": "Charlie", "id": float64(3)},
+		{"name": "Alice", "id": float64(1)},
+		{"name": "Bob", "id": float64(2)},
+	}
+
+	t.Run("sort by name ascending", func(t *testing.T) {
+		input := make([]map[string]interface{}, len(items))
+		copy(input, items)
+
+		result := sortByField(input, "name")
+
+		if result[0]["name"] != "Alice" {
+			t.Errorf("sortByField()[0].name = %v, want Alice", result[0]["name"])
+		}
+		if result[1]["name"] != "Bob" {
+			t.Errorf("sortByField()[1].name = %v, want Bob", result[1]["name"])
+		}
+		if result[2]["name"] != "Charlie" {
+			t.Errorf("sortByField()[2].name = %v, want Charlie", result[2]["name"])
+		}
+	})
+
+	t.Run("sort by name descending", func(t *testing.T) {
+		input := make([]map[string]interface{}, len(items))
+		copy(input, items)
+
+		result := sortByField(input, "-name")
+
+		if result[0]["name"] != "Charlie" {
+			t.Errorf("sortByField()[0].name = %v, want Charlie", result[0]["name"])
+		}
+		if result[2]["name"] != "Alice" {
+			t.Errorf("sortByField()[2].name = %v, want Alice", result[2]["name"])
+		}
+	})
+
+	t.Run("sort by numeric field", func(t *testing.T) {
+		input := make([]map[string]interface{}, len(items))
+		copy(input, items)
+
+		result := sortByField(input, "id")
+
+		if result[0]["id"] != float64(1) {
+			t.Errorf("sortByField()[0].id = %v, want 1", result[0]["id"])
+		}
+		if result[2]["id"] != float64(3) {
+			t.Errorf("sortByField()[2].id = %v, want 3", result[2]["id"])
+		}
+	})
+}
+
+func TestSelectColumns(t *testing.T) {
+	items := []map[string]interface{}{
+		{"name": "Alice", "email": "alice@example.com", "id": float64(1)},
+		{"name": "Bob", "email": "bob@example.com", "id": float64(2)},
+	}
+
+	result := selectColumns(items, []string{"name", "id"})
+
+	if len(result) != 2 {
+		t.Fatalf("selectColumns() len = %d, want 2", len(result))
+	}
+
+	// Check first item has only selected columns
+	if _, exists := result[0]["email"]; exists {
+		t.Error("selectColumns() should not include email column")
+	}
+
+	if result[0]["name"] != "Alice" {
+		t.Errorf("selectColumns()[0].name = %v, want Alice", result[0]["name"])
+	}
+
+	if result[0]["id"] != float64(1) {
+		t.Errorf("selectColumns()[0].id = %v, want 1", result[0]["id"])
+	}
+}
+
+func TestCompareValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        interface{}
+		b        interface{}
+		expected int
+	}{
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: 0,
+		},
+		{
+			name:     "a nil",
+			a:        nil,
+			b:        "test",
+			expected: -1,
+		},
+		{
+			name:     "b nil",
+			a:        "test",
+			b:        nil,
+			expected: 1,
+		},
+		{
+			name:     "numeric less",
+			a:        float64(1),
+			b:        float64(2),
+			expected: -1,
+		},
+		{
+			name:     "numeric equal",
+			a:        float64(1),
+			b:        float64(1),
+			expected: 0,
+		},
+		{
+			name:     "numeric greater",
+			a:        float64(2),
+			b:        float64(1),
+			expected: 1,
+		},
+		{
+			name:     "string less",
+			a:        "alice",
+			b:        "bob",
+			expected: -1,
+		},
+		{
+			name:     "string equal",
+			a:        "alice",
+			b:        "alice",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := compareValues(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("compareValues(%v, %v) = %d, want %d", tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected float64
+		ok       bool
+	}{
+		{
+			name:     "float64",
+			input:    float64(1.5),
+			expected: 1.5,
+			ok:       true,
+		},
+		{
+			name:     "float32",
+			input:    float32(1.5),
+			expected: 1.5,
+			ok:       true,
+		},
+		{
+			name:     "int",
+			input:    1,
+			expected: 1,
+			ok:       true,
+		},
+		{
+			name:     "int64",
+			input:    int64(1),
+			expected: 1,
+			ok:       true,
+		},
+		{
+			name:     "string",
+			input:    "not a number",
+			expected: 0,
+			ok:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := toFloat64(tt.input)
+			if ok != tt.ok {
+				t.Errorf("toFloat64(%v) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if ok && result != tt.expected {
+				t.Errorf("toFloat64(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasFilteringOptions(t *testing.T) {
+	// Save original values
+	origFilterText := filterText
+	origFilterColumns := filterColumns
+	origSortField := sortField
+
+	defer func() {
+		// Restore original values
+		filterText = origFilterText
+		filterColumns = origFilterColumns
+		sortField = origSortField
+	}()
+
+	t.Run("no options set", func(t *testing.T) {
+		filterText = ""
+		filterColumns = nil
+		sortField = ""
+
+		if hasFilteringOptions() {
+			t.Error("hasFilteringOptions() = true, want false")
+		}
+	})
+
+	t.Run("filter text set", func(t *testing.T) {
+		filterText = "test"
+		filterColumns = nil
+		sortField = ""
+
+		if !hasFilteringOptions() {
+			t.Error("hasFilteringOptions() = false, want true")
+		}
+	})
+
+	t.Run("filter columns set", func(t *testing.T) {
+		filterText = ""
+		filterColumns = []string{"name"}
+		sortField = ""
+
+		if !hasFilteringOptions() {
+			t.Error("hasFilteringOptions() = false, want true")
+		}
+	})
+
+	t.Run("sort field set", func(t *testing.T) {
+		filterText = ""
+		filterColumns = nil
+		sortField = "name"
+
+		if !hasFilteringOptions() {
+			t.Error("hasFilteringOptions() = false, want true")
+		}
+	})
+}

--- a/commands/internal/options/alias.go
+++ b/commands/internal/options/alias.go
@@ -1,0 +1,49 @@
+package options
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AliasSetOptions contains options for alias set command
+type AliasSetOptions struct {
+	Name      string
+	Expansion string
+}
+
+// Validate validates the options
+func (o *AliasSetOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("alias name is required")
+	}
+	if o.Expansion == "" {
+		return fmt.Errorf("alias expansion is required")
+	}
+	if strings.Contains(o.Name, " ") {
+		return fmt.Errorf("alias name cannot contain spaces")
+	}
+	return nil
+}
+
+// AliasListOptions contains options for alias list command
+type AliasListOptions struct {
+	// No options needed for list
+}
+
+// Validate validates the options
+func (o *AliasListOptions) Validate() error {
+	return nil
+}
+
+// AliasDeleteOptions contains options for alias delete command
+type AliasDeleteOptions struct {
+	Name string
+}
+
+// Validate validates the options
+func (o *AliasDeleteOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("alias name is required")
+	}
+	return nil
+}

--- a/commands/internal/options/alias_test.go
+++ b/commands/internal/options/alias_test.go
@@ -1,0 +1,101 @@
+package options
+
+import (
+	"testing"
+)
+
+func TestAliasSetOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *AliasSetOptions
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid options",
+			opts: &AliasSetOptions{
+				Name:      "ca",
+				Expansion: "assignments list --course-id 123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			opts: &AliasSetOptions{
+				Name:      "",
+				Expansion: "assignments list",
+			},
+			wantErr: true,
+			errMsg:  "alias name is required",
+		},
+		{
+			name: "empty expansion",
+			opts: &AliasSetOptions{
+				Name:      "ca",
+				Expansion: "",
+			},
+			wantErr: true,
+			errMsg:  "alias expansion is required",
+		},
+		{
+			name: "name with spaces",
+			opts: &AliasSetOptions{
+				Name:      "my alias",
+				Expansion: "assignments list",
+			},
+			wantErr: true,
+			errMsg:  "alias name cannot contain spaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AliasSetOptions.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("AliasSetOptions.Validate() error = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestAliasListOptions_Validate(t *testing.T) {
+	opts := &AliasListOptions{}
+	if err := opts.Validate(); err != nil {
+		t.Errorf("AliasListOptions.Validate() error = %v, want nil", err)
+	}
+}
+
+func TestAliasDeleteOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *AliasDeleteOptions
+		wantErr bool
+	}{
+		{
+			name: "valid options",
+			opts: &AliasDeleteOptions{
+				Name: "ca",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			opts: &AliasDeleteOptions{
+				Name: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AliasDeleteOptions.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/commands/internal/options/context.go
+++ b/commands/internal/options/context.go
@@ -1,0 +1,65 @@
+package options
+
+import "fmt"
+
+// ContextSetOptions contains options for context set command
+type ContextSetOptions struct {
+	Type string
+	ID   int64
+}
+
+// Validate validates the options
+func (o *ContextSetOptions) Validate() error {
+	if o.Type == "" {
+		return fmt.Errorf("context type is required")
+	}
+	if o.ID <= 0 {
+		return fmt.Errorf("ID must be a positive number")
+	}
+	validTypes := []string{"course", "course_id", "course-id", "assignment", "assignment_id", "assignment-id", "user", "user_id", "user-id", "account", "account_id", "account-id"}
+	isValid := false
+	for _, t := range validTypes {
+		if o.Type == t {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		return fmt.Errorf("unknown context type %q. Valid types: course, assignment, user, account", o.Type)
+	}
+	return nil
+}
+
+// ContextShowOptions contains options for context show command
+type ContextShowOptions struct {
+	// No options needed for show
+}
+
+// Validate validates the options
+func (o *ContextShowOptions) Validate() error {
+	return nil
+}
+
+// ContextClearOptions contains options for context clear command
+type ContextClearOptions struct {
+	Type string // Optional: if empty, clears all context
+}
+
+// Validate validates the options
+func (o *ContextClearOptions) Validate() error {
+	if o.Type == "" {
+		return nil // Empty is valid, means clear all
+	}
+	validTypes := []string{"course", "course_id", "course-id", "assignment", "assignment_id", "assignment-id", "user", "user_id", "user-id", "account", "account_id", "account-id"}
+	isValid := false
+	for _, t := range validTypes {
+		if o.Type == t {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		return fmt.Errorf("unknown context type %q. Valid types: course, assignment, user, account", o.Type)
+	}
+	return nil
+}

--- a/commands/internal/options/context_test.go
+++ b/commands/internal/options/context_test.go
@@ -1,0 +1,170 @@
+package options
+
+import (
+	"testing"
+)
+
+func TestContextSetOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *ContextSetOptions
+		wantErr bool
+	}{
+		{
+			name: "valid course type",
+			opts: &ContextSetOptions{
+				Type: "course",
+				ID:   123,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid assignment type",
+			opts: &ContextSetOptions{
+				Type: "assignment",
+				ID:   456,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid user type",
+			opts: &ContextSetOptions{
+				Type: "user",
+				ID:   789,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid account type",
+			opts: &ContextSetOptions{
+				Type: "account",
+				ID:   1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid course_id alias",
+			opts: &ContextSetOptions{
+				Type: "course_id",
+				ID:   123,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid course-id alias",
+			opts: &ContextSetOptions{
+				Type: "course-id",
+				ID:   123,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty type",
+			opts: &ContextSetOptions{
+				Type: "",
+				ID:   123,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid type",
+			opts: &ContextSetOptions{
+				Type: "invalid",
+				ID:   123,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero ID",
+			opts: &ContextSetOptions{
+				Type: "course",
+				ID:   0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative ID",
+			opts: &ContextSetOptions{
+				Type: "course",
+				ID:   -1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ContextSetOptions.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestContextShowOptions_Validate(t *testing.T) {
+	opts := &ContextShowOptions{}
+	if err := opts.Validate(); err != nil {
+		t.Errorf("ContextShowOptions.Validate() error = %v, want nil", err)
+	}
+}
+
+func TestContextClearOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *ContextClearOptions
+		wantErr bool
+	}{
+		{
+			name: "empty type clears all",
+			opts: &ContextClearOptions{
+				Type: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid course type",
+			opts: &ContextClearOptions{
+				Type: "course",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid assignment type",
+			opts: &ContextClearOptions{
+				Type: "assignment",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid user type",
+			opts: &ContextClearOptions{
+				Type: "user",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid account type",
+			opts: &ContextClearOptions{
+				Type: "account",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid type",
+			opts: &ContextClearOptions{
+				Type: "invalid",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ContextClearOptions.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -27,6 +27,11 @@ var (
 	commit       string
 	buildDate    string
 
+	// Output filtering flags
+	filterText    string   // Filter results by text (substring match)
+	filterColumns []string // Select specific columns to display
+	sortField     string   // Sort results by field
+
 	// Auto-updater instance
 	autoUpdater *update.AutoUpdater
 )
@@ -95,6 +100,11 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&globalLimit, "limit", 0, "Limit number of results for list operations (0 = unlimited)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Print curl commands instead of executing requests")
 	rootCmd.PersistentFlags().BoolVar(&showToken, "show-token", false, "Show actual token in dry-run output (default: redacted)")
+
+	// Output filtering flags
+	rootCmd.PersistentFlags().StringVar(&filterText, "filter", "", "Filter results by text (case-insensitive substring match)")
+	rootCmd.PersistentFlags().StringSliceVar(&filterColumns, "columns", nil, "Select specific columns to display (comma-separated)")
+	rootCmd.PersistentFlags().StringVar(&sortField, "sort", "", "Sort results by field (prefix with - for descending, e.g., -name)")
 
 	// Bind flags to viper
 	viper.BindPFlag("instance", rootCmd.PersistentFlags().Lookup("instance"))


### PR DESCRIPTION
## Summary

This PR adds several major UX enhancements inspired by modern CLIs like gh, kubectl, and stripe-cli:

- **Alias System** - Create command shortcuts like `canvas alias set ca "assignments list --course-id 123"`
- **Output Filtering** - Filter and sort results with `--filter`, `--columns`, `--sort` flags
- **Context Management** - Set default course/assignment IDs with `canvas context set course 123`
- **Enhanced Dry-Run** - Preview delete/update operations before executing

## Changes

### Alias System (gh-inspired)
```bash
canvas alias set ca "assignments list --course-id 123"
canvas alias list
canvas alias delete ca
canvas ca  # expands automatically
```

### Output Filtering
```bash
canvas courses list --filter "CS 101"
canvas assignments list --columns id,name,due_at
canvas users list --sort -name  # descending
```

### Context Management (kubectl-inspired)
```bash
canvas context set course 123
canvas assignments list  # uses context
canvas context show
canvas context clear
```

### Enhanced Dry-Run
```bash
canvas assignments delete 456 --course-id 123 --dry-run
# Shows: Name, Points, Status before asking to confirm

canvas assignments update 456 --name "New" --dry-run
# Shows: All planned changes
```

## Files Changed

- `cmd/canvas/main.go` - Alias expansion before command execution
- `commands/alias.go` - New alias command (set, list, delete)
- `commands/context.go` - New context command (set, show, clear)
- `commands/filtering.go` - Filtering logic (filter, sort, columns)
- `commands/helpers.go` - Apply filtering in formatOutput functions
- `commands/root.go` - Add global --filter, --columns, --sort flags
- `commands/confirm.go` - Enhanced dry-run for delete/update
- `commands/assignments.go` - Context integration example
- `internal/config/config.go` - Add Aliases and Context to config

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks pass (gofmt, golangci-lint, go vet, tests)
- [x] Manual testing of alias workflow
- [x] Manual testing of context workflow
- [ ] Test filtering with real Canvas data
- [ ] Test dry-run with real Canvas instance