### PR TITLE
feat: CLI infrastructure improvements and UX enhancements

### DIFF
--- a/commands/admins.go
+++ b/commands/admins.go
@@ -464,7 +464,7 @@ func runAdminsAdd(ctx context.Context, client *api.Client, opts *options.AdminsA
 		return fmt.Errorf("failed to add admin: %w", err)
 	}
 
-	fmt.Printf("Admin added successfully (User ID: %d)\n", admin.UserID)
+	printInfo("Admin added successfully (User ID: %d)\n", admin.UserID)
 	logger.LogCommandComplete(ctx, "admins.add", 1)
 	return nil
 }
@@ -493,7 +493,7 @@ func runAdminsRemove(ctx context.Context, client *api.Client, opts *options.Admi
 		return fmt.Errorf("failed to remove admin: %w", err)
 	}
 
-	fmt.Printf("Admin removed successfully (User ID: %d)\n", admin.UserID)
+	printInfo("Admin removed successfully (User ID: %d)\n", admin.UserID)
 	logger.LogCommandComplete(ctx, "admins.remove", 1)
 	return nil
 }
@@ -578,7 +578,7 @@ func runRolesCreate(ctx context.Context, client *api.Client, opts *options.Roles
 		return fmt.Errorf("failed to create role: %w", err)
 	}
 
-	fmt.Printf("Role created successfully (ID: %d)\n", role.ID)
+	printInfo("Role created successfully (ID: %d)\n", role.ID)
 	logger.LogCommandComplete(ctx, "roles.create", 1)
 	return nil
 }
@@ -607,7 +607,7 @@ func runRolesUpdate(ctx context.Context, client *api.Client, opts *options.Roles
 		return fmt.Errorf("failed to update role: %w", err)
 	}
 
-	fmt.Printf("Role updated successfully (ID: %d)\n", role.ID)
+	printInfo("Role updated successfully (ID: %d)\n", role.ID)
 	logger.LogCommandComplete(ctx, "roles.update", 1)
 	return nil
 }

--- a/commands/announcements.go
+++ b/commands/announcements.go
@@ -381,7 +381,7 @@ func runAnnouncementsDelete(ctx context.Context, client *api.Client, opts *optio
 		return fmt.Errorf("failed to delete announcement: %w", err)
 	}
 
-	fmt.Printf("Announcement %d deleted successfully\n", opts.AnnouncementID)
+	printInfo("Announcement %d deleted successfully\n", opts.AnnouncementID)
 	logger.LogCommandComplete(ctx, "announcements.delete", 1)
 	return nil
 }

--- a/commands/assignment_groups.go
+++ b/commands/assignment_groups.go
@@ -329,7 +329,7 @@ func runAssignmentGroupsCreate(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to create assignment group: %w", err)
 	}
 
-	fmt.Printf("Assignment group created successfully (ID: %d)\n", group.ID)
+	printInfo("Assignment group created successfully (ID: %d)\n", group.ID)
 	logger.LogCommandComplete(ctx, "assignment_groups.create", 1)
 	return formatOutput(group, nil)
 }
@@ -373,7 +373,7 @@ func runAssignmentGroupsUpdate(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to update assignment group: %w", err)
 	}
 
-	fmt.Printf("Assignment group updated successfully (ID: %d)\n", group.ID)
+	printInfo("Assignment group updated successfully (ID: %d)\n", group.ID)
 	logger.LogCommandComplete(ctx, "assignment_groups.update", 1)
 	return formatOutput(group, nil)
 }

--- a/commands/assignments.go
+++ b/commands/assignments.go
@@ -458,7 +458,7 @@ func runAssignmentsCreate(ctx context.Context, client *api.Client, cmd *cobra.Co
 		return fmt.Errorf("failed to create assignment: %w", err)
 	}
 
-	fmt.Printf("Assignment created successfully!\n")
+	printInfo("Assignment created successfully!\n")
 	fmt.Printf("  ID: %d\n", assignment.ID)
 	fmt.Printf("  Name: %s\n", assignment.Name)
 	fmt.Printf("  Points: %.1f\n", assignment.PointsPossible)
@@ -588,7 +588,7 @@ func runAssignmentsUpdate(ctx context.Context, client *api.Client, cmd *cobra.Co
 		return fmt.Errorf("failed to update assignment: %w", err)
 	}
 
-	fmt.Printf("Assignment updated successfully!\n")
+	printInfo("Assignment updated successfully!\n")
 	fmt.Printf("  ID: %d\n", assignment.ID)
 	fmt.Printf("  Name: %s\n", assignment.Name)
 	fmt.Printf("  Points: %.1f\n", assignment.PointsPossible)
@@ -667,7 +667,7 @@ func runAssignmentsDelete(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to delete assignment: %w", err)
 	}
 
-	fmt.Printf("Assignment %d deleted successfully.\n", opts.AssignmentID)
+	printInfo("Assignment %d deleted successfully.\n", opts.AssignmentID)
 
 	logger.LogCommandComplete(ctx, "assignments.delete", 1)
 	return nil

--- a/commands/assignments.go
+++ b/commands/assignments.go
@@ -459,16 +459,16 @@ func runAssignmentsCreate(ctx context.Context, client *api.Client, cmd *cobra.Co
 	}
 
 	printInfo("Assignment created successfully!\n")
-	fmt.Printf("  ID: %d\n", assignment.ID)
-	fmt.Printf("  Name: %s\n", assignment.Name)
-	fmt.Printf("  Points: %.1f\n", assignment.PointsPossible)
+	printInfo("  ID: %d\n", assignment.ID)
+	printInfo("  Name: %s\n", assignment.Name)
+	printInfo("  Points: %.1f\n", assignment.PointsPossible)
 	if !assignment.DueAt.IsZero() {
-		fmt.Printf("  Due: %s\n", assignment.DueAt.Format("2006-01-02 15:04"))
+		printInfo("  Due: %s\n", assignment.DueAt.Format("2006-01-02 15:04"))
 	}
 	if assignment.Published {
-		fmt.Printf("  Status: Published\n")
+		printInfo("  Status: Published\n")
 	} else {
-		fmt.Printf("  Status: Unpublished\n")
+		printInfo("  Status: Unpublished\n")
 	}
 
 	logger.LogCommandComplete(ctx, "assignments.create", 1)
@@ -589,16 +589,16 @@ func runAssignmentsUpdate(ctx context.Context, client *api.Client, cmd *cobra.Co
 	}
 
 	printInfo("Assignment updated successfully!\n")
-	fmt.Printf("  ID: %d\n", assignment.ID)
-	fmt.Printf("  Name: %s\n", assignment.Name)
-	fmt.Printf("  Points: %.1f\n", assignment.PointsPossible)
+	printInfo("  ID: %d\n", assignment.ID)
+	printInfo("  Name: %s\n", assignment.Name)
+	printInfo("  Points: %.1f\n", assignment.PointsPossible)
 	if !assignment.DueAt.IsZero() {
-		fmt.Printf("  Due: %s\n", assignment.DueAt.Format("2006-01-02 15:04"))
+		printInfo("  Due: %s\n", assignment.DueAt.Format("2006-01-02 15:04"))
 	}
 	if assignment.Published {
-		fmt.Printf("  Status: Published\n")
+		printInfo("  Status: Published\n")
 	} else {
-		fmt.Printf("  Status: Unpublished\n")
+		printInfo("  Status: Unpublished\n")
 	}
 
 	logger.LogCommandComplete(ctx, "assignments.update", 1)

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -326,11 +325,10 @@ func runAuthLogin(ctx context.Context, opts *options.AuthLoginOptions) error {
 	}
 
 	// Save token
-	configDir, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get config directory: %w", err)
 	}
-	configDir = configDir + "/.canvas-cli"
 
 	tokenStore := auth.NewFallbackTokenStore(configDir)
 	if err := tokenStore.Save(opts.InstanceName, token); err != nil {
@@ -355,8 +353,8 @@ func runAuthLogin(ctx context.Context, opts *options.AuthLoginOptions) error {
 		}
 	}
 
-	fmt.Printf("\n✓ Successfully authenticated with %s\n", opts.InstanceName)
-	fmt.Printf("Token expires: %s\n", token.Expiry.Format(time.RFC3339))
+	printInfo("\n✓ Successfully authenticated with %s\n", opts.InstanceName)
+	printInfo("Token expires: %s\n", token.Expiry.Format(time.RFC3339))
 
 	return nil
 }
@@ -391,11 +389,10 @@ func runAuthLogout(ctx context.Context, opts *options.AuthLogoutOptions) error {
 	}
 
 	// Get config directory
-	configDir, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get config directory: %w", err)
 	}
-	configDir = configDir + "/.canvas-cli"
 
 	// Delete token
 	tokenStore := auth.NewFallbackTokenStore(configDir)
@@ -403,7 +400,7 @@ func runAuthLogout(ctx context.Context, opts *options.AuthLogoutOptions) error {
 		return fmt.Errorf("failed to delete token: %w", err)
 	}
 
-	fmt.Printf("✓ Successfully logged out from %s\n", instanceName)
+	printInfo("✓ Successfully logged out from %s\n", instanceName)
 
 	return nil
 }
@@ -422,11 +419,10 @@ func runAuthStatus(ctx context.Context, opts *options.AuthStatusOptions) error {
 	}
 
 	// Get config directory
-	configDir, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get config directory: %w", err)
 	}
-	configDir = configDir + "/.canvas-cli"
 
 	tokenStore := auth.NewFallbackTokenStore(configDir)
 
@@ -591,16 +587,16 @@ func runAuthTokenSet(ctx context.Context, opts *options.AuthTokenSetOptions) err
 		if err := cfg.UpdateInstance(opts.InstanceName, instance); err != nil {
 			return fmt.Errorf("failed to update instance: %w", err)
 		}
-		fmt.Printf("✓ Updated API token for %s\n", opts.InstanceName)
+		printInfo("✓ Updated API token for %s\n", opts.InstanceName)
 	} else {
 		if err := cfg.AddInstance(instance); err != nil {
 			return fmt.Errorf("failed to add instance: %w", err)
 		}
-		fmt.Printf("✓ Created instance %s with API token authentication\n", opts.InstanceName)
+		printInfo("✓ Created instance %s with API token authentication\n", opts.InstanceName)
 	}
 
-	fmt.Printf("URL: %s\n", normalizedURL)
-	fmt.Printf("Auth type: token\n")
+	printInfo("URL: %s\n", normalizedURL)
+	printInfo("Auth type: token\n")
 
 	return nil
 }
@@ -628,7 +624,7 @@ func runAuthTokenRemove(ctx context.Context, opts *options.AuthTokenRemoveOption
 	fmt.Scanln(&confirm)
 
 	if confirm != "y" && confirm != "Y" {
-		fmt.Println("Token removal cancelled")
+		printInfoln("Token removal cancelled")
 		return nil
 	}
 
@@ -639,12 +635,12 @@ func runAuthTokenRemove(ctx context.Context, opts *options.AuthTokenRemoveOption
 		return fmt.Errorf("failed to update instance: %w", err)
 	}
 
-	fmt.Printf("✓ Removed API token from %s\n", opts.InstanceName)
+	printInfo("✓ Removed API token from %s\n", opts.InstanceName)
 
 	// Suggest next steps if no auth remains
 	if !instance.HasOAuth() {
-		fmt.Printf("\nNote: Instance %s now has no authentication configured.\n", opts.InstanceName)
-		fmt.Println("Use 'canvas auth login' or 'canvas auth token set' to authenticate.")
+		printInfo("\nNote: Instance %s now has no authentication configured.\n", opts.InstanceName)
+		printInfoln("Use 'canvas auth login' or 'canvas auth token set' to authenticate.")
 	}
 
 	return nil

--- a/commands/cache.go
+++ b/commands/cache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jjuanrivvera/canvas-cli/internal/cache"
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
 )
 
 var cacheCmd = &cobra.Command{
@@ -65,11 +66,11 @@ func init() {
 }
 
 func getCacheDir() (string, error) {
-	home, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
+		return "", fmt.Errorf("failed to get config directory: %w", err)
 	}
-	return filepath.Join(home, ".canvas-cli", "cache"), nil
+	return filepath.Join(configDir, "cache"), nil
 }
 
 func runCacheStats(_ *cobra.Command, _ []string) error {

--- a/commands/calendar.go
+++ b/commands/calendar.go
@@ -492,7 +492,7 @@ func runCalendarDelete(ctx context.Context, client *api.Client, opts *options.Ca
 		return fmt.Errorf("failed to delete calendar event: %w", err)
 	}
 
-	fmt.Printf("Calendar event %d deleted successfully\n", opts.EventID)
+	printInfo("Calendar event %d deleted successfully\n", opts.EventID)
 	logger.LogCommandComplete(ctx, "calendar.delete", 1)
 	return nil
 }

--- a/commands/config.go
+++ b/commands/config.go
@@ -301,14 +301,14 @@ func runConfigAdd(ctx context.Context, opts *options.ConfigAddOptions) error {
 		return fmt.Errorf("failed to add instance: %w", err)
 	}
 
-	fmt.Printf("Instance %q added successfully.\n", opts.Name)
+	printInfo("Instance %q added successfully.\n", opts.Name)
 
 	if cfg.DefaultInstance == opts.Name {
-		fmt.Printf("Set as default instance.\n")
+		printInfo("Set as default instance.\n")
 	}
 
-	fmt.Println("\nNext step: Authenticate with this instance:")
-	fmt.Printf("  canvas auth login --instance %s\n", opts.Name)
+	printInfoln("\nNext step: Authenticate with this instance:")
+	printInfo("  canvas auth login --instance %s\n", opts.Name)
 
 	logger.LogCommandComplete(ctx, "config.add", 1)
 	return nil
@@ -648,11 +648,10 @@ func getAPIClientForInstanceByName(instanceName string) (*api.Client, error) {
 		}
 	} else {
 		// OAuth flow - load token from store
-		configDir, err := os.UserHomeDir()
+		configDir, err := config.GetConfigDir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get home directory: %w", err)
+			return nil, fmt.Errorf("failed to get config directory: %w", err)
 		}
-		configDir = configDir + "/.canvas-cli"
 
 		tokenStore := auth.NewFallbackTokenStore(configDir)
 		token, err := tokenStore.Load(instance.Name)

--- a/commands/conversations.go
+++ b/commands/conversations.go
@@ -585,7 +585,7 @@ func runConversationsReply(ctx context.Context, client *api.Client, opts *option
 
 	logger.LogCommandComplete(ctx, "conversations.reply", 1)
 
-	fmt.Printf("Reply added successfully (conversation ID: %d)\n", conversation.ID)
+	printInfo("Reply added successfully (conversation ID: %d)\n", conversation.ID)
 	return formatOutput(conversation, nil)
 }
 

--- a/commands/courses.go
+++ b/commands/courses.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/logging"
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/options"
 	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/progress"
 )
 
 // coursesCmd represents the courses command group
@@ -93,6 +94,11 @@ func runCoursesList(ctx context.Context, client *api.Client, opts *options.Cours
 		"search_term":      opts.SearchTerm,
 	})
 
+	spin := progress.New("Fetching courses...")
+	if !quiet {
+		spin.Start()
+	}
+
 	var courses []api.Course
 	var err error
 
@@ -110,6 +116,7 @@ func runCoursesList(ctx context.Context, client *api.Client, opts *options.Cours
 		}
 
 		courses, err = accountsService.ListCourses(ctx, opts.AccountID, reqOpts)
+		spin.Stop()
 		if err != nil {
 			logger.LogCommandError(ctx, "courses.list", err, map[string]interface{}{
 				"account_id": opts.AccountID,
@@ -130,6 +137,7 @@ func runCoursesList(ctx context.Context, client *api.Client, opts *options.Cours
 		}
 
 		courses, err = coursesService.List(ctx, reqOpts)
+		spin.Stop()
 		if err != nil {
 			logger.LogCommandError(ctx, "courses.list", err, map[string]interface{}{
 				"enrollment_type": opts.EnrollmentType,
@@ -301,7 +309,7 @@ func runCoursesCreate(ctx context.Context, client *api.Client, opts *options.Cou
 		return fmt.Errorf("failed to create course: %w", err)
 	}
 
-	fmt.Printf("Course created successfully (ID: %d)\n", course.ID)
+	printInfo("Course created successfully (ID: %d)\n", course.ID)
 	if err := formatOutput(course, nil); err != nil {
 		return fmt.Errorf("failed to print result: %w", err)
 	}
@@ -393,7 +401,7 @@ func runCoursesUpdate(ctx context.Context, client *api.Client, opts *options.Cou
 		return fmt.Errorf("failed to update course: %w", err)
 	}
 
-	fmt.Printf("Course updated successfully (ID: %d)\n", course.ID)
+	printInfo("Course updated successfully (ID: %d)\n", course.ID)
 	if err := formatOutput(course, nil); err != nil {
 		return fmt.Errorf("failed to print result: %w", err)
 	}

--- a/commands/discussions.go
+++ b/commands/discussions.go
@@ -617,7 +617,7 @@ func runDiscussionsDelete(ctx context.Context, client *api.Client, opts *options
 	}
 
 	logger.LogCommandComplete(ctx, "discussions.delete", 1)
-	fmt.Printf("Discussion %d deleted successfully\n", opts.TopicID)
+	printInfo("Discussion %d deleted successfully\n", opts.TopicID)
 	return nil
 }
 

--- a/commands/enrollments.go
+++ b/commands/enrollments.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/logging"
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/options"
 	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/progress"
 )
 
 // enrollmentsCmd represents the enrollments command group
@@ -329,19 +330,23 @@ func runEnrollmentsList(ctx context.Context, client *api.Client, opts *options.E
 	}
 
 	// List enrollments based on context
+	spin := progress.New("Fetching enrollments...")
+	if !quiet {
+		spin.Start()
+	}
+
 	var enrollments []api.Enrollment
 	var contextName string
 	var err error
 
 	if opts.CourseID > 0 {
-		// Course context - list all enrollments in the course
 		enrollments, err = enrollmentsService.ListCourse(ctx, opts.CourseID, apiOpts)
 		contextName = fmt.Sprintf("course %d", opts.CourseID)
 	} else {
-		// User context - list all enrollments for the user
 		enrollments, err = enrollmentsService.ListUser(ctx, opts.UserID, apiOpts)
 		contextName = fmt.Sprintf("user %d", opts.UserID)
 	}
+	spin.Stop()
 
 	if err != nil {
 		logger.LogCommandError(ctx, "enrollments.list", err, map[string]interface{}{
@@ -439,7 +444,7 @@ func runEnrollmentsCreate(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to create enrollment: %w", err)
 	}
 
-	fmt.Printf("Enrollment created successfully (ID: %d)\n", enrollment.ID)
+	printInfo("Enrollment created successfully (ID: %d)\n", enrollment.ID)
 	logger.LogCommandComplete(ctx, "enrollments.create", 1)
 	return formatOutput(enrollment, nil)
 }

--- a/commands/external_tools.go
+++ b/commands/external_tools.go
@@ -455,7 +455,7 @@ func runExtToolsCreate(ctx context.Context, client *api.Client, opts *options.Ex
 		return fmt.Errorf("failed to create external tool: %w", err)
 	}
 
-	fmt.Printf("External tool created successfully (ID: %d)\n", tool.ID)
+	printInfo("External tool created successfully (ID: %d)\n", tool.ID)
 	logger.LogCommandComplete(ctx, "external_tools.create", 1)
 	return formatOutput(tool, nil)
 }
@@ -512,7 +512,7 @@ func runExtToolsUpdate(ctx context.Context, client *api.Client, opts *options.Ex
 		return fmt.Errorf("failed to update external tool: %w", err)
 	}
 
-	fmt.Printf("External tool updated successfully (ID: %d)\n", tool.ID)
+	printInfo("External tool updated successfully (ID: %d)\n", tool.ID)
 	logger.LogCommandComplete(ctx, "external_tools.update", 1)
 	return formatOutput(tool, nil)
 }
@@ -556,7 +556,7 @@ func runExtToolsDelete(ctx context.Context, client *api.Client, opts *options.Ex
 		return fmt.Errorf("failed to delete external tool: %w", err)
 	}
 
-	fmt.Printf("External tool %d deleted successfully\n", opts.ToolID)
+	printInfo("External tool %d deleted successfully\n", opts.ToolID)
 	logger.LogCommandComplete(ctx, "external_tools.delete", 1)
 	return nil
 }

--- a/commands/files.go
+++ b/commands/files.go
@@ -386,10 +386,10 @@ func runFilesUpload(ctx context.Context, client *api.Client, opts *options.Files
 	}
 
 	printInfo("✅ File uploaded successfully\n\n")
-	fmt.Printf("   ID: %d\n", uploadedFile.ID)
-	fmt.Printf("   Name: %s\n", uploadedFile.DisplayName)
-	fmt.Printf("   Size: %s\n", formatFileSize(uploadedFile.Size))
-	fmt.Printf("   URL: %s\n", uploadedFile.URL)
+	printInfo("   ID: %d\n", uploadedFile.ID)
+	printInfo("   Name: %s\n", uploadedFile.DisplayName)
+	printInfo("   Size: %s\n", formatFileSize(uploadedFile.Size))
+	printInfo("   URL: %s\n", uploadedFile.URL)
 
 	logger.LogCommandComplete(ctx, "files.upload", 1)
 	return nil

--- a/commands/files.go
+++ b/commands/files.go
@@ -385,7 +385,7 @@ func runFilesUpload(ctx context.Context, client *api.Client, opts *options.Files
 		return fmt.Errorf("failed to upload file: %w", err)
 	}
 
-	fmt.Printf("✅ File uploaded successfully\n\n")
+	printInfo("✅ File uploaded successfully\n\n")
 	fmt.Printf("   ID: %d\n", uploadedFile.ID)
 	fmt.Printf("   Name: %s\n", uploadedFile.DisplayName)
 	fmt.Printf("   Size: %s\n", formatFileSize(uploadedFile.Size))
@@ -466,7 +466,7 @@ func runFilesDelete(ctx context.Context, client *api.Client, opts *options.Files
 		return fmt.Errorf("failed to delete file: %w", err)
 	}
 
-	fmt.Printf("✅ File %d deleted successfully\n", opts.FileID)
+	printInfo("✅ File %d deleted successfully\n", opts.FileID)
 
 	logger.LogCommandComplete(ctx, "files.delete", 1)
 	return nil

--- a/commands/global_options.go
+++ b/commands/global_options.go
@@ -1,0 +1,39 @@
+package commands
+
+// GlobalOptions wraps all root-level flags into a single struct.
+// Existing global vars are kept for backward compatibility; this struct
+// provides a clean accessor for new and migrated commands.
+type GlobalOptions struct {
+	ConfigFile    string
+	InstanceURL   string
+	OutputFormat  string
+	Verbose       bool
+	Quiet         bool
+	NoCache       bool
+	AsUserID      int64
+	Limit         int
+	DryRun        bool
+	ShowToken     bool
+	FilterText    string
+	FilterColumns []string
+	SortField     string
+}
+
+// GetGlobalOptions returns a snapshot of the current global flag values.
+func GetGlobalOptions() *GlobalOptions {
+	return &GlobalOptions{
+		ConfigFile:    cfgFile,
+		InstanceURL:   instanceURL,
+		OutputFormat:  outputFormat,
+		Verbose:       verbose,
+		Quiet:         quiet,
+		NoCache:       noCache,
+		AsUserID:      asUserID,
+		Limit:         globalLimit,
+		DryRun:        dryRun,
+		ShowToken:     showToken,
+		FilterText:    filterText,
+		FilterColumns: filterColumns,
+		SortField:     sortField,
+	}
+}

--- a/commands/grades.go
+++ b/commands/grades.go
@@ -562,7 +562,7 @@ func runGradesColumnsCreate(ctx context.Context, client *api.Client, opts *optio
 		return fmt.Errorf("failed to create custom column: %w", err)
 	}
 
-	fmt.Printf("Custom column created successfully (ID: %d)\n", column.ID)
+	printInfo("Custom column created successfully (ID: %d)\n", column.ID)
 
 	logger.LogCommandComplete(ctx, "grades.columns.create", 1)
 	return formatOutput(column, nil)
@@ -604,7 +604,7 @@ func runGradesColumnsUpdate(ctx context.Context, client *api.Client, opts *optio
 		return fmt.Errorf("failed to update custom column: %w", err)
 	}
 
-	fmt.Printf("Custom column updated successfully (ID: %d)\n", column.ID)
+	printInfo("Custom column updated successfully (ID: %d)\n", column.ID)
 
 	logger.LogCommandComplete(ctx, "grades.columns.update", 1)
 	return formatOutput(column, nil)

--- a/commands/groups.go
+++ b/commands/groups.go
@@ -718,7 +718,7 @@ func runGroupsCreate(ctx context.Context, client *api.Client, opts *options.Grou
 		return fmt.Errorf("failed to create group: %w", err)
 	}
 
-	fmt.Printf("Group created successfully (ID: %d)\n", group.ID)
+	printInfo("Group created successfully (ID: %d)\n", group.ID)
 	if err := formatOutput(group, nil); err != nil {
 		return err
 	}
@@ -765,7 +765,7 @@ func runGroupsUpdate(ctx context.Context, client *api.Client, opts *options.Grou
 		return fmt.Errorf("failed to update group: %w", err)
 	}
 
-	fmt.Printf("Group updated successfully (ID: %d)\n", group.ID)
+	printInfo("Group updated successfully (ID: %d)\n", group.ID)
 	if err := formatOutput(group, nil); err != nil {
 		return err
 	}
@@ -801,7 +801,7 @@ func runGroupsDelete(ctx context.Context, client *api.Client, opts *options.Grou
 		return fmt.Errorf("failed to delete group: %w", err)
 	}
 
-	fmt.Printf("Group %d deleted successfully\n", group.ID)
+	printInfo("Group %d deleted successfully\n", group.ID)
 
 	logger.LogCommandComplete(ctx, "groups.delete", 1)
 	return nil
@@ -984,7 +984,7 @@ func runGroupsCategoriesCreate(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to create category: %w", err)
 	}
 
-	fmt.Printf("Category created successfully (ID: %d)\n", category.ID)
+	printInfo("Category created successfully (ID: %d)\n", category.ID)
 	if err := formatOutput(category, nil); err != nil {
 		return err
 	}
@@ -1028,7 +1028,7 @@ func runGroupsCategoriesUpdate(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to update category: %w", err)
 	}
 
-	fmt.Printf("Category updated successfully (ID: %d)\n", category.ID)
+	printInfo("Category updated successfully (ID: %d)\n", category.ID)
 	if err := formatOutput(category, nil); err != nil {
 		return err
 	}
@@ -1066,7 +1066,7 @@ func runGroupsCategoriesDelete(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to delete category: %w", err)
 	}
 
-	fmt.Printf("Category %d deleted successfully\n", category.ID)
+	printInfo("Category %d deleted successfully\n", category.ID)
 
 	logger.LogCommandComplete(ctx, "groups.categories.delete", 1)
 	return nil

--- a/commands/modules.go
+++ b/commands/modules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/logging"
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/options"
 	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/progress"
 )
 
 // modulesCmd represents the modules command group
@@ -712,7 +713,12 @@ func runModulesList(ctx context.Context, client *api.Client, opts *options.Modul
 		StudentID:  opts.StudentID,
 	}
 
+	spin := progress.New("Fetching modules...")
+	if !quiet {
+		spin.Start()
+	}
 	modules, err := modulesService.List(ctx, opts.CourseID, apiOpts)
+	spin.Stop()
 	if err != nil {
 		logger.LogCommandError(ctx, "modules.list", err, map[string]interface{}{
 			"course_id": opts.CourseID,
@@ -903,7 +909,7 @@ func runModulesDelete(ctx context.Context, client *api.Client, opts *options.Mod
 		return fmt.Errorf("failed to delete module: %w", err)
 	}
 
-	fmt.Printf("Module %d deleted successfully\n", opts.ModuleID)
+	printInfo("Module %d deleted successfully\n", opts.ModuleID)
 
 	logger.LogCommandComplete(ctx, "modules.delete", 1)
 	return nil
@@ -1260,7 +1266,7 @@ func runModulesItemsDelete(ctx context.Context, client *api.Client, opts *option
 		return fmt.Errorf("failed to delete module item: %w", err)
 	}
 
-	fmt.Printf("Module item %d deleted successfully\n", opts.ItemID)
+	printInfo("Module item %d deleted successfully\n", opts.ItemID)
 
 	logger.LogCommandComplete(ctx, "modules.items.delete", 1)
 	return nil

--- a/commands/outcomes.go
+++ b/commands/outcomes.go
@@ -512,11 +512,11 @@ func runOutcomesCreate(ctx context.Context, client *api.Client, opts *options.Ou
 		return fmt.Errorf("failed to create outcome: %w", err)
 	}
 
-	printInfo("Outcome created successfully")
 	if link.Outcome != nil {
-		fmt.Printf(" (ID: %d)", link.Outcome.ID)
+		printInfo("Outcome created successfully (ID: %d)\n", link.Outcome.ID)
+	} else {
+		printInfo("Outcome created successfully\n")
 	}
-	fmt.Println()
 
 	if err := formatOutput(link, nil); err != nil {
 		return fmt.Errorf("failed to print results: %w", err)

--- a/commands/outcomes.go
+++ b/commands/outcomes.go
@@ -512,7 +512,7 @@ func runOutcomesCreate(ctx context.Context, client *api.Client, opts *options.Ou
 		return fmt.Errorf("failed to create outcome: %w", err)
 	}
 
-	fmt.Printf("Outcome created successfully")
+	printInfo("Outcome created successfully")
 	if link.Outcome != nil {
 		fmt.Printf(" (ID: %d)", link.Outcome.ID)
 	}
@@ -564,7 +564,7 @@ func runOutcomesUpdate(ctx context.Context, client *api.Client, opts *options.Ou
 		return fmt.Errorf("failed to update outcome: %w", err)
 	}
 
-	fmt.Printf("Outcome updated successfully (ID: %d)\n", outcome.ID)
+	printInfo("Outcome updated successfully (ID: %d)\n", outcome.ID)
 	if err := formatOutput(outcome, nil); err != nil {
 		return fmt.Errorf("failed to print results: %w", err)
 	}

--- a/commands/overrides.go
+++ b/commands/overrides.go
@@ -347,7 +347,7 @@ func runOverridesCreate(ctx context.Context, client *api.Client, opts *options.O
 		return fmt.Errorf("failed to create override: %w", err)
 	}
 
-	fmt.Printf("Override created successfully (ID: %d)\n", override.ID)
+	printInfo("Override created successfully (ID: %d)\n", override.ID)
 	logger.LogCommandComplete(ctx, "overrides.create", 1)
 	return formatOutput(override, nil)
 }
@@ -407,7 +407,7 @@ func runOverridesUpdate(ctx context.Context, client *api.Client, opts *options.O
 		return fmt.Errorf("failed to update override: %w", err)
 	}
 
-	fmt.Printf("Override updated successfully (ID: %d)\n", override.ID)
+	printInfo("Override updated successfully (ID: %d)\n", override.ID)
 	logger.LogCommandComplete(ctx, "overrides.update", 1)
 	return formatOutput(override, nil)
 }

--- a/commands/pages.go
+++ b/commands/pages.go
@@ -538,7 +538,7 @@ func runPagesDelete(ctx context.Context, client *api.Client, opts *options.Pages
 	}
 
 	logger.LogCommandComplete(ctx, "pages.delete", 1)
-	fmt.Printf("Page '%s' deleted successfully\n", opts.URLOrID)
+	printInfo("Page '%s' deleted successfully\n", opts.URLOrID)
 	return nil
 }
 

--- a/commands/peer_reviews.go
+++ b/commands/peer_reviews.go
@@ -241,7 +241,7 @@ func runPeerReviewsDelete(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to delete peer review: %w", err)
 	}
 
-	fmt.Println("Peer review deleted successfully")
+	printInfoln("Peer review deleted successfully")
 	logger.LogCommandComplete(ctx, "peer_reviews.delete", 1)
 	return nil
 }

--- a/commands/planner.go
+++ b/commands/planner.go
@@ -564,7 +564,7 @@ func runPlannerNotesDelete(ctx context.Context, client *api.Client, opts *option
 		return fmt.Errorf("failed to delete planner note: %w", err)
 	}
 
-	fmt.Printf("Planner note %d deleted successfully\n", opts.NoteID)
+	printInfo("Planner note %d deleted successfully\n", opts.NoteID)
 
 	logger.LogCommandComplete(ctx, "planner.notes.delete", 1)
 	return nil

--- a/commands/quizzes.go
+++ b/commands/quizzes.go
@@ -635,7 +635,7 @@ func runQuizzesCreate(ctx context.Context, client *api.Client, opts *options.Qui
 		return fmt.Errorf("failed to create quiz: %w", err)
 	}
 
-	fmt.Printf("Quiz created successfully (ID: %d)\n", quiz.ID)
+	printInfo("Quiz created successfully (ID: %d)\n", quiz.ID)
 	if err := formatOutput(quiz, nil); err != nil {
 		return fmt.Errorf("failed to print results: %w", err)
 	}
@@ -723,7 +723,7 @@ func runQuizzesUpdate(ctx context.Context, client *api.Client, opts *options.Qui
 		return fmt.Errorf("failed to update quiz: %w", err)
 	}
 
-	fmt.Printf("Quiz updated successfully (ID: %d)\n", quiz.ID)
+	printInfo("Quiz updated successfully (ID: %d)\n", quiz.ID)
 	if err := formatOutput(quiz, nil); err != nil {
 		return fmt.Errorf("failed to print results: %w", err)
 	}
@@ -762,7 +762,7 @@ func runQuizzesDelete(ctx context.Context, client *api.Client, opts *options.Qui
 		return fmt.Errorf("failed to delete quiz: %w", err)
 	}
 
-	fmt.Printf("Quiz %d deleted\n", quiz.ID)
+	printInfo("Quiz %d deleted\n", quiz.ID)
 
 	logger.LogCommandComplete(ctx, "quizzes.delete", 1)
 	return nil
@@ -853,7 +853,7 @@ func runQuizzesQuestionsCreate(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to create question: %w", err)
 	}
 
-	fmt.Printf("Question created successfully (ID: %d)\n", question.ID)
+	printInfo("Question created successfully (ID: %d)\n", question.ID)
 	if err := formatOutput(question, nil); err != nil {
 		return fmt.Errorf("failed to print results: %w", err)
 	}
@@ -893,7 +893,7 @@ func runQuizzesQuestionsDelete(ctx context.Context, client *api.Client, opts *op
 		return fmt.Errorf("failed to delete question: %w", err)
 	}
 
-	fmt.Printf("Question %d deleted\n", opts.QuestionID)
+	printInfo("Question %d deleted\n", opts.QuestionID)
 
 	logger.LogCommandComplete(ctx, "quizzes.questions.delete", 1)
 	return nil

--- a/commands/rubrics.go
+++ b/commands/rubrics.go
@@ -390,7 +390,7 @@ func runRubricsCreate(ctx context.Context, client *api.Client, opts *options.Rub
 		return fmt.Errorf("failed to create rubric: %w", err)
 	}
 
-	fmt.Printf("Rubric created successfully (ID: %d)\n", rubric.ID)
+	printInfo("Rubric created successfully (ID: %d)\n", rubric.ID)
 	logger.LogCommandComplete(ctx, "rubrics.create", 1)
 	return formatOutput(rubric, nil)
 }
@@ -428,7 +428,7 @@ func runRubricsUpdate(ctx context.Context, client *api.Client, opts *options.Rub
 		return fmt.Errorf("failed to update rubric: %w", err)
 	}
 
-	fmt.Printf("Rubric updated successfully (ID: %d)\n", rubric.ID)
+	printInfo("Rubric updated successfully (ID: %d)\n", rubric.ID)
 	logger.LogCommandComplete(ctx, "rubrics.update", 1)
 	return formatOutput(rubric, nil)
 }

--- a/commands/sections.go
+++ b/commands/sections.go
@@ -398,7 +398,7 @@ func runSectionsCreate(ctx context.Context, client *api.Client, opts *options.Se
 		return fmt.Errorf("failed to create section: %w", err)
 	}
 
-	fmt.Printf("Section created successfully (ID: %d)\n", section.ID)
+	printInfo("Section created successfully (ID: %d)\n", section.ID)
 	logger.LogCommandComplete(ctx, "sections.create", 1)
 	return formatOutput(section, nil)
 }
@@ -442,7 +442,7 @@ func runSectionsUpdate(ctx context.Context, client *api.Client, opts *options.Se
 		return fmt.Errorf("failed to update section: %w", err)
 	}
 
-	fmt.Printf("Section updated successfully (ID: %d)\n", section.ID)
+	printInfo("Section updated successfully (ID: %d)\n", section.ID)
 	logger.LogCommandComplete(ctx, "sections.update", 1)
 	return formatOutput(section, nil)
 }

--- a/commands/sis_imports.go
+++ b/commands/sis_imports.go
@@ -402,7 +402,7 @@ func runSISCreate(ctx context.Context, client *api.Client, opts *options.SISImpo
 	}
 
 	printInfo("SIS import created successfully (ID: %d)\n", sisImport.ID)
-	fmt.Printf("Workflow state: %s\n", sisImport.WorkflowState)
+	printInfo("Workflow state: %s\n", sisImport.WorkflowState)
 	logger.LogCommandComplete(ctx, "sis_imports.create", 1)
 	return nil
 }

--- a/commands/sis_imports.go
+++ b/commands/sis_imports.go
@@ -401,7 +401,7 @@ func runSISCreate(ctx context.Context, client *api.Client, opts *options.SISImpo
 		return fmt.Errorf("failed to create SIS import: %w", err)
 	}
 
-	fmt.Printf("SIS import created successfully (ID: %d)\n", sisImport.ID)
+	printInfo("SIS import created successfully (ID: %d)\n", sisImport.ID)
 	fmt.Printf("Workflow state: %s\n", sisImport.WorkflowState)
 	logger.LogCommandComplete(ctx, "sis_imports.create", 1)
 	return nil

--- a/commands/submissions.go
+++ b/commands/submissions.go
@@ -446,23 +446,23 @@ func runSubmissionsGrade(ctx context.Context, client *api.Client, opts *options.
 	}
 
 	printInfo("✅ Successfully graded submission for %s\n", userName)
-	fmt.Printf("   User ID: %d\n", submission.UserID)
-	fmt.Printf("   Assignment ID: %d\n", submission.AssignmentID)
+	printInfo("   User ID: %d\n", submission.UserID)
+	printInfo("   Assignment ID: %d\n", submission.AssignmentID)
 
 	if submission.Score > 0 {
-		fmt.Printf("   Score: %.1f\n", submission.Score)
+		printInfo("   Score: %.1f\n", submission.Score)
 	}
 
 	if submission.Grade != "" {
-		fmt.Printf("   Grade: %s\n", submission.Grade)
+		printInfo("   Grade: %s\n", submission.Grade)
 	}
 
 	if submission.ExcusedTLN {
-		fmt.Printf("   ✓ Excused\n")
+		printInfo("   ✓ Excused\n")
 	}
 
 	if !submission.GradedAt.IsZero() {
-		fmt.Printf("   Graded: %s\n", submission.GradedAt.Format("2006-01-02 15:04"))
+		printInfo("   Graded: %s\n", submission.GradedAt.Format("2006-01-02 15:04"))
 	}
 
 	logger.LogCommandComplete(ctx, "submissions.grade", 1)

--- a/commands/submissions.go
+++ b/commands/submissions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/options"
 	"github.com/jjuanrivvera/canvas-cli/internal/api"
 	"github.com/jjuanrivvera/canvas-cli/internal/batch"
+	"github.com/jjuanrivvera/canvas-cli/internal/progress"
 )
 
 // submissionsCmd represents the submissions command group
@@ -322,7 +323,12 @@ func runSubmissionsList(ctx context.Context, client *api.Client, opts *options.S
 	}
 
 	// List submissions
+	spin := progress.New("Fetching submissions...")
+	if !quiet {
+		spin.Start()
+	}
 	submissions, err := submissionsService.List(ctx, opts.CourseID, opts.AssignmentID, apiOpts)
+	spin.Stop()
 	if err != nil {
 		logger.LogCommandError(ctx, "submissions.list", err, map[string]interface{}{
 			"course_id":     opts.CourseID,
@@ -439,7 +445,7 @@ func runSubmissionsGrade(ctx context.Context, client *api.Client, opts *options.
 		userName = submission.User.Name
 	}
 
-	fmt.Printf("✅ Successfully graded submission for %s\n", userName)
+	printInfo("✅ Successfully graded submission for %s\n", userName)
 	fmt.Printf("   User ID: %d\n", submission.UserID)
 	fmt.Printf("   Assignment ID: %d\n", submission.AssignmentID)
 
@@ -645,7 +651,7 @@ func runSubmissionsAddComment(ctx context.Context, client *api.Client, opts *opt
 	}
 
 	logger.LogCommandComplete(ctx, "submissions.add-comment", 1)
-	fmt.Printf("Comment added successfully to submission for user %d\n", submission.UserID)
+	printInfo("Comment added successfully to submission for user %d\n", submission.UserID)
 	return nil
 }
 
@@ -679,6 +685,6 @@ func runSubmissionsDeleteComment(ctx context.Context, client *api.Client, opts *
 	}
 
 	logger.LogCommandComplete(ctx, "submissions.delete-comment", 1)
-	fmt.Printf("Comment %d deleted successfully\n", opts.CommentID)
+	printInfo("Comment %d deleted successfully\n", opts.CommentID)
 	return nil
 }

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -187,11 +186,10 @@ func getAPIClientForInstance(instanceName string) (*api.Client, error) {
 	}
 
 	// Get config directory
-	configDir, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
+		return nil, fmt.Errorf("failed to get config directory: %w", err)
 	}
-	configDir = configDir + "/.canvas-cli"
 
 	// Load token
 	tokenStore := auth.NewFallbackTokenStore(configDir)

--- a/commands/telemetry.go
+++ b/commands/telemetry.go
@@ -180,12 +180,12 @@ func runTelemetryStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check for telemetry data
-	home, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get config directory: %w", err)
 	}
 
-	telemetryDir := filepath.Join(home, ".canvas-cli", "telemetry")
+	telemetryDir := filepath.Join(configDir, "telemetry")
 	files, err := os.ReadDir(telemetryDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -222,12 +222,12 @@ func runTelemetryStatus(cmd *cobra.Command, args []string) error {
 }
 
 func runTelemetryShow(cmd *cobra.Command, args []string) error {
-	home, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get config directory: %w", err)
 	}
 
-	telemetryDir := filepath.Join(home, ".canvas-cli", "telemetry")
+	telemetryDir := filepath.Join(configDir, "telemetry")
 	files, err := os.ReadDir(telemetryDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -275,12 +275,12 @@ func runTelemetryShow(cmd *cobra.Command, args []string) error {
 }
 
 func runTelemetryClear(cmd *cobra.Command, args []string) error {
-	home, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get config directory: %w", err)
 	}
 
-	telemetryDir := filepath.Join(home, ".canvas-cli", "telemetry")
+	telemetryDir := filepath.Join(configDir, "telemetry")
 
 	// Check if directory exists
 	if _, err := os.Stat(telemetryDir); os.IsNotExist(err) {

--- a/commands/update.go
+++ b/commands/update.go
@@ -152,8 +152,8 @@ func runUpdateNow(ctx context.Context, opts *options.UpdateOptions) error {
 	}
 
 	if result.Updated {
-		fmt.Printf("\n\033[32m✓ Successfully updated from v%s to v%s\033[0m\n", result.FromVersion, result.ToVersion)
-		fmt.Println("  Restart the CLI to use the new version.")
+		printInfo("\n\033[32m✓ Successfully updated from v%s to v%s\033[0m\n", result.FromVersion, result.ToVersion)
+		printInfoln("  Restart the CLI to use the new version.")
 	}
 
 	logger.LogCommandComplete(ctx, "update.now", 1)

--- a/commands/users.go
+++ b/commands/users.go
@@ -513,13 +513,13 @@ func runUsersCreate(ctx context.Context, client *api.Client, cmd *cobra.Command,
 	logger.LogCommandComplete(ctx, "users.create", 1)
 
 	printInfo("User created successfully!\n")
-	fmt.Printf("  ID: %d\n", user.ID)
-	fmt.Printf("  Name: %s\n", user.Name)
+	printInfo("  ID: %d\n", user.ID)
+	printInfo("  Name: %s\n", user.Name)
 	if user.LoginID != "" {
-		fmt.Printf("  Login: %s\n", user.LoginID)
+		printInfo("  Login: %s\n", user.LoginID)
 	}
 	if user.Email != "" {
-		fmt.Printf("  Email: %s\n", user.Email)
+		printInfo("  Email: %s\n", user.Email)
 	}
 
 	return nil
@@ -588,13 +588,13 @@ func runUsersUpdate(ctx context.Context, client *api.Client, opts *options.Users
 	logger.LogCommandComplete(ctx, "users.update", 1)
 
 	printInfo("User updated successfully!\n")
-	fmt.Printf("  ID: %d\n", user.ID)
-	fmt.Printf("  Name: %s\n", user.Name)
+	printInfo("  ID: %d\n", user.ID)
+	printInfo("  Name: %s\n", user.Name)
 	if user.LoginID != "" {
-		fmt.Printf("  Login: %s\n", user.LoginID)
+		printInfo("  Login: %s\n", user.LoginID)
 	}
 	if user.Email != "" {
-		fmt.Printf("  Email: %s\n", user.Email)
+		printInfo("  Email: %s\n", user.Email)
 	}
 
 	return nil

--- a/commands/users.go
+++ b/commands/users.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/logging"
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/options"
 	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/progress"
 )
 
 // usersCmd represents the users command group
@@ -312,19 +313,23 @@ func runUsersList(ctx context.Context, client *api.Client, opts *options.UsersLi
 	}
 
 	// List users based on context
+	spin := progress.New("Fetching users...")
+	if !quiet {
+		spin.Start()
+	}
+
 	var users []api.User
 	var contextName string
 	var err error
 
 	if accountID > 0 {
-		// Account context - list all users in the account
 		users, err = usersService.List(ctx, accountID, listOpts)
 		contextName = fmt.Sprintf("account %d", accountID)
 	} else {
-		// Course context - list users enrolled in the course
 		users, err = usersService.ListCourseUsers(ctx, opts.CourseID, listOpts)
 		contextName = fmt.Sprintf("course %d", opts.CourseID)
 	}
+	spin.Stop()
 
 	if err != nil {
 		logger.LogCommandError(ctx, "users.list", err, map[string]interface{}{
@@ -507,7 +512,7 @@ func runUsersCreate(ctx context.Context, client *api.Client, cmd *cobra.Command,
 
 	logger.LogCommandComplete(ctx, "users.create", 1)
 
-	fmt.Printf("User created successfully!\n")
+	printInfo("User created successfully!\n")
 	fmt.Printf("  ID: %d\n", user.ID)
 	fmt.Printf("  Name: %s\n", user.Name)
 	if user.LoginID != "" {
@@ -582,7 +587,7 @@ func runUsersUpdate(ctx context.Context, client *api.Client, opts *options.Users
 
 	logger.LogCommandComplete(ctx, "users.update", 1)
 
-	fmt.Printf("User updated successfully!\n")
+	printInfo("User updated successfully!\n")
 	fmt.Printf("  ID: %d\n", user.ID)
 	fmt.Printf("  Name: %s\n", user.Name)
 	if user.LoginID != "" {

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,511 @@
+# Canvas CLI Best Practices
+
+This guide covers best practices for using Canvas CLI effectively and efficiently.
+
+## Table of Contents
+
+- [Initial Setup](#initial-setup)
+- [Authentication](#authentication)
+- [Working with Multiple Instances](#working-with-multiple-instances)
+- [Productivity Features](#productivity-features)
+- [Output and Filtering](#output-and-filtering)
+- [Scripting and Automation](#scripting-and-automation)
+- [Common Workflows](#common-workflows)
+- [Performance Tips](#performance-tips)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Initial Setup
+
+### 1. Install Shell Completion
+
+Enable tab completion for faster command entry:
+
+```bash
+# Bash
+canvas completion bash > /etc/bash_completion.d/canvas
+
+# Zsh
+canvas completion zsh > "${fpath[1]}/_canvas"
+
+# Fish
+canvas completion fish > ~/.config/fish/completions/canvas.fish
+```
+
+### 2. Run Diagnostics
+
+Verify your installation is working correctly:
+
+```bash
+canvas doctor
+```
+
+This checks connectivity, authentication, and configuration.
+
+### 3. Enable Auto-Updates
+
+Stay current with the latest features and fixes:
+
+```bash
+canvas update enable
+canvas update status
+```
+
+---
+
+## Authentication
+
+### Choose the Right Method
+
+| Method | Use Case | Security |
+|--------|----------|----------|
+| OAuth (default) | Interactive use, personal accounts | High - tokens auto-refresh |
+| API Token | Scripts, automation, CI/CD | Medium - store securely |
+
+### OAuth Login (Recommended for Interactive Use)
+
+```bash
+# Login with browser-based OAuth
+canvas auth login https://canvas.example.com
+
+# Login to a named instance
+canvas config add prod --url https://canvas.example.com
+canvas auth login --instance prod
+```
+
+### API Token (For Automation)
+
+```bash
+# Set API token for an instance
+canvas auth token set myinstance
+
+# Use in scripts (set environment variable)
+export CANVAS_TOKEN="your-token-here"
+```
+
+### Check Authentication Status
+
+```bash
+canvas auth status
+```
+
+---
+
+## Working with Multiple Instances
+
+### Configure Named Instances
+
+```bash
+# Add instances
+canvas config add prod --url https://canvas.example.com
+canvas config add staging --url https://staging.canvas.example.com
+canvas config add dev --url https://dev.canvas.example.com
+
+# List all instances
+canvas config list
+
+# Switch between instances
+canvas config use prod
+canvas config use staging
+```
+
+### Per-Command Instance Override
+
+```bash
+# Use a specific instance for one command
+canvas courses list --instance staging
+```
+
+### Set Default Account
+
+For admin operations, set a default account ID:
+
+```bash
+canvas config account 1
+```
+
+---
+
+## Productivity Features
+
+### Command Aliases
+
+Create shortcuts for frequently used commands:
+
+```bash
+# Create aliases
+canvas alias set courses "courses list"
+canvas alias set hw "assignments list --course-id 123"
+canvas alias set ungraded "submissions list --workflow-state submitted"
+canvas alias set students "users list --enrollment-type student"
+
+# Use aliases
+canvas courses
+canvas hw
+canvas ungraded --course-id 456 --assignment-id 789
+
+# Manage aliases
+canvas alias list
+canvas alias delete hw
+```
+
+**Best Practices for Aliases:**
+
+- Use short, memorable names
+- Include common flags you always use
+- Don't include IDs that change frequently (use context instead)
+
+### Context Management
+
+Set default values to avoid repetitive typing:
+
+```bash
+# Set course context for a grading session
+canvas context set course 12345
+canvas context set assignment 67890
+
+# Now these commands use context automatically
+canvas submissions list          # Uses course 12345, assignment 67890
+canvas submissions grade 111 --grade 95
+
+# View current context
+canvas context show
+
+# Clear when switching tasks
+canvas context clear
+```
+
+**Best Practices for Context:**
+
+- Set context at the start of a focused work session
+- Clear context when switching courses/tasks
+- Use explicit flags when working across multiple courses
+- Context + aliases = maximum efficiency
+
+### Combine Aliases with Context
+
+```bash
+# Set up your workflow
+canvas context set course 12345
+canvas alias set subs "submissions list"
+canvas alias set grade "submissions grade"
+
+# Super efficient grading
+canvas subs --assignment-id 456
+canvas grade 111 --grade 95 --comment "Great work!"
+canvas grade 222 --grade 88
+```
+
+---
+
+## Output and Filtering
+
+### Choose the Right Output Format
+
+| Format | Use Case |
+|--------|----------|
+| `table` | Human reading in terminal (default) |
+| `json` | Scripting, piping to jq, automation |
+| `yaml` | Configuration files, readable structured data |
+| `csv` | Spreadsheet import, Excel, Google Sheets |
+
+```bash
+# Examples
+canvas courses list                    # Table for viewing
+canvas courses list -o json            # JSON for scripts
+canvas users list -o csv > users.csv   # CSV for spreadsheets
+```
+
+### Filter Results
+
+```bash
+# Text filter (case-insensitive, searches all fields)
+canvas courses list --filter "Fall 2024"
+canvas users list --course-id 123 --filter "student"
+
+# Select specific columns
+canvas assignments list --course-id 123 --columns id,name,due_at
+
+# Sort results
+canvas assignments list --course-id 123 --sort due_at      # Ascending
+canvas assignments list --course-id 123 --sort -due_at     # Descending
+
+# Combine all options
+canvas assignments list --course-id 123 \
+  --filter "exam" \
+  --columns id,name,due_at,points_possible \
+  --sort -due_at
+```
+
+### Limit Results
+
+```bash
+# Get only first 10 results
+canvas courses list --limit 10
+
+# Useful for testing or quick checks
+canvas submissions list --course-id 123 --assignment-id 456 --limit 5
+```
+
+---
+
+## Scripting and Automation
+
+### Use JSON Output
+
+Always use `-o json` in scripts for reliable parsing:
+
+```bash
+#!/bin/bash
+# Get all course IDs
+COURSES=$(canvas courses list -o json | jq -r '.[].id')
+
+for COURSE_ID in $COURSES; do
+    echo "Processing course $COURSE_ID"
+    canvas assignments list --course-id "$COURSE_ID" -o json
+done
+```
+
+### Dry-Run for Testing
+
+Preview commands before executing:
+
+```bash
+# See what API calls would be made
+canvas assignments create --course-id 123 --name "Test" --dry-run
+
+# Shows curl command with redacted token
+curl -X POST 'https://canvas.example.com/api/v1/courses/123/assignments' \
+  -H 'Authorization: Bearer [REDACTED]' \
+  ...
+```
+
+### Bulk Operations
+
+Use CSV for bulk grading:
+
+```bash
+# Prepare grades.csv:
+# student_id,grade,comment
+# 123,95,Great work!
+# 456,88,Good effort
+
+canvas submissions bulk-grade \
+  --course-id 123 \
+  --assignment-id 456 \
+  --csv grades.csv
+```
+
+### Error Handling in Scripts
+
+```bash
+#!/bin/bash
+set -e  # Exit on error
+
+# Check authentication first
+if ! canvas auth status > /dev/null 2>&1; then
+    echo "Not authenticated. Run: canvas auth login"
+    exit 1
+fi
+
+# Proceed with operations
+canvas courses list -o json
+```
+
+---
+
+## Common Workflows
+
+### Grading Workflow
+
+```bash
+# 1. Set context for the grading session
+canvas context set course 12345
+canvas context set assignment 67890
+
+# 2. List ungraded submissions
+canvas submissions list --workflow-state submitted
+
+# 3. Grade individual submissions
+canvas submissions grade 111 --grade 95 --comment "Excellent!"
+canvas submissions grade 222 --grade 88
+
+# 4. Or bulk grade from CSV
+canvas submissions bulk-grade --csv grades.csv
+
+# 5. Clear context when done
+canvas context clear
+```
+
+### Course Setup Workflow
+
+```bash
+# 1. Create assignment groups
+canvas assignment-groups create --course-id 123 --name "Homework" --weight 30
+canvas assignment-groups create --course-id 123 --name "Exams" --weight 50
+canvas assignment-groups create --course-id 123 --name "Projects" --weight 20
+
+# 2. Create assignments
+canvas assignments create --course-id 123 \
+  --name "Homework 1" \
+  --assignment-group-id 456 \
+  --points 100 \
+  --due-at "2024-09-15T23:59:00Z"
+
+# 3. Create modules
+canvas modules create --course-id 123 --name "Week 1"
+canvas modules items create --course-id 123 --module-id 789 \
+  --type Assignment --content-id 456
+```
+
+### User Management Workflow
+
+```bash
+# List students in a course
+canvas users list --course-id 123 --enrollment-type student
+
+# Search for a user
+canvas users search --course-id 123 --search-term "john"
+
+# Export to spreadsheet
+canvas users list --course-id 123 -o csv > students.csv
+```
+
+### Course Migration Workflow
+
+```bash
+# Sync from source to destination
+canvas sync course \
+  --source-instance prod \
+  --source-course 123 \
+  --dest-instance staging \
+  --dest-course 456 \
+  --interactive
+```
+
+---
+
+## Performance Tips
+
+### Enable Caching
+
+Caching is enabled by default. Manage it as needed:
+
+```bash
+# View cache stats
+canvas cache stats
+
+# Clear cache when data is stale
+canvas cache clear
+
+# Disable cache for one command
+canvas courses list --no-cache
+```
+
+### Use Pagination Wisely
+
+```bash
+# For large datasets, use --limit to paginate manually
+canvas users list --course-id 123 --limit 100
+
+# Or let the CLI handle it (may take time for large datasets)
+canvas users list --course-id 123
+```
+
+### Batch Operations
+
+For multiple similar operations, use bulk commands when available:
+
+```bash
+# Slow: Individual grade commands
+for id in 1 2 3 4 5; do
+    canvas submissions grade $id --grade 100
+done
+
+# Fast: Bulk grade from CSV
+canvas submissions bulk-grade --csv grades.csv
+```
+
+---
+
+## Troubleshooting
+
+### Run Diagnostics
+
+```bash
+canvas doctor
+```
+
+### Enable Verbose Output
+
+```bash
+canvas courses list -v
+```
+
+### Check API Calls
+
+```bash
+# See exact API request
+canvas courses list --dry-run
+```
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| "Not authenticated" | Run `canvas auth login` |
+| "Rate limited" | Wait and retry, or reduce request frequency |
+| "Course not found" | Check course ID and permissions |
+| "Token expired" | Re-authenticate with `canvas auth login` |
+
+### Clear State
+
+```bash
+# Clear all cached data
+canvas cache clear
+
+# Clear context
+canvas context clear
+
+# Re-authenticate
+canvas auth logout
+canvas auth login
+```
+
+---
+
+## Quick Reference
+
+### Essential Commands
+
+```bash
+canvas auth login                 # Authenticate
+canvas courses list               # List courses
+canvas assignments list -c 123    # List assignments
+canvas submissions list -c 123 -a 456  # List submissions
+canvas context set course 123     # Set context
+canvas alias set x "command"      # Create alias
+```
+
+### Global Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output` | `-o` | Output format (table/json/yaml/csv) |
+| `--verbose` | `-v` | Show detailed output |
+| `--filter` | | Filter results by text |
+| `--columns` | | Select columns to display |
+| `--sort` | | Sort by field (- for descending) |
+| `--limit` | | Limit number of results |
+| `--dry-run` | | Show curl command without executing |
+| `--no-cache` | | Bypass cache |
+| `--instance` | | Use specific Canvas instance |
+
+### Getting Help
+
+```bash
+canvas --help              # General help
+canvas <command> --help    # Command-specific help
+canvas doctor              # Diagnose issues
+```

--- a/internal/batch/sync.go
+++ b/internal/batch/sync.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/term"
-
 	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/terminal"
 )
 
 // ConflictResolution defines how to handle conflicts during sync
@@ -27,7 +26,7 @@ const promptTimeout = 60 * time.Second
 
 // isTerminal checks if stdin is a terminal (TTY)
 func isTerminal() bool {
-	return term.IsTerminal(int(os.Stdin.Fd()))
+	return terminal.IsStdinTerminal()
 }
 
 // promptWithTimeout reads user input with a timeout

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,9 +271,10 @@ func (c *Config) Save() error {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
-	// Invalidate cache so next Load() picks up the saved changes
+	// Update cache with a clone so next Load() picks up the saved changes
+	// without allowing the caller to mutate the cached copy
 	cacheMu.Lock()
-	cachedConfig = c
+	cachedConfig = c.Clone()
 	cacheMu.Unlock()
 
 	return nil

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -294,17 +294,16 @@ func (d *Doctor) checkDiskSpace(ctx context.Context) Check {
 		Status:      StatusPass,
 	}
 
-	// Get home directory
-	home, err := os.UserHomeDir()
+	// Check if directory is writable
+	configDir, err := config.GetConfigDir()
 	if err != nil {
 		check.Status = StatusWarning
-		check.Message = fmt.Sprintf("Could not determine home directory: %v", err)
+		check.Message = fmt.Sprintf("Could not determine config directory: %v", err)
 		check.Duration = time.Since(start)
 		return check
 	}
 
-	// Check if directory is writable
-	cacheDir := home + "/.canvas-cli/cache"
+	cacheDir := configDir + "/cache"
 	if err := os.MkdirAll(cacheDir, 0700); err != nil {
 		check.Status = StatusWarning
 		check.Message = fmt.Sprintf("Cache directory not writable: %v", err)
@@ -327,17 +326,14 @@ func (d *Doctor) checkPermissions(ctx context.Context) Check {
 		Status:      StatusPass,
 	}
 
-	// Get home directory
-	home, err := os.UserHomeDir()
+	// Check config directory
+	configDir, err := config.GetConfigDir()
 	if err != nil {
 		check.Status = StatusWarning
-		check.Message = fmt.Sprintf("Could not determine home directory: %v", err)
+		check.Message = fmt.Sprintf("Could not determine config directory: %v", err)
 		check.Duration = time.Since(start)
 		return check
 	}
-
-	// Check config directory
-	configDir := home + "/.canvas-cli"
 	if info, err := os.Stat(configDir); err != nil {
 		if os.IsNotExist(err) {
 			check.Status = StatusWarning

--- a/internal/progress/spinner.go
+++ b/internal/progress/spinner.go
@@ -1,0 +1,93 @@
+package progress
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/jjuanrivvera/canvas-cli/internal/terminal"
+)
+
+// Spinner displays an animated spinner on stderr while a long operation runs.
+// It is TTY-aware: when stderr is not a terminal (piped output), all
+// operations become no-ops so machine-readable output is never polluted.
+type Spinner struct {
+	mu      sync.Mutex
+	message string
+	active  bool
+	done    chan struct{}
+	frames  []string
+}
+
+// New creates a new Spinner with the given initial message.
+func New(message string) *Spinner {
+	return &Spinner{
+		message: message,
+		frames:  []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+	}
+}
+
+// Start begins the spinner animation. Safe to call multiple times;
+// subsequent calls are no-ops while the spinner is already running.
+func (s *Spinner) Start() {
+	if !terminal.IsStderrTerminal() {
+		return
+	}
+
+	s.mu.Lock()
+	if s.active {
+		s.mu.Unlock()
+		return
+	}
+	s.active = true
+	s.done = make(chan struct{})
+	s.mu.Unlock()
+
+	go s.run()
+}
+
+// Stop halts the spinner and clears the line.
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return
+	}
+	s.active = false
+	close(s.done)
+	s.mu.Unlock()
+
+	// Clear the spinner line
+	if terminal.IsStderrTerminal() {
+		fmt.Fprintf(os.Stderr, "\r\033[K")
+	}
+}
+
+// UpdateMessage changes the spinner message while it is running.
+func (s *Spinner) UpdateMessage(msg string) {
+	s.mu.Lock()
+	s.message = msg
+	s.mu.Unlock()
+}
+
+func (s *Spinner) run() {
+	ticker := time.NewTicker(80 * time.Millisecond)
+	defer ticker.Stop()
+
+	i := 0
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			msg := s.message
+			s.mu.Unlock()
+
+			frame := s.frames[i%len(s.frames)]
+			fmt.Fprintf(os.Stderr, "\r\033[K%s %s", frame, msg)
+			i++
+		}
+	}
+}

--- a/internal/progress/spinner_test.go
+++ b/internal/progress/spinner_test.go
@@ -1,0 +1,41 @@
+package progress
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSpinner_StartStop(t *testing.T) {
+	s := New("Loading...")
+	// In CI/test environments stderr is not a TTY, so Start is a no-op.
+	// This verifies there are no panics or races.
+	s.Start()
+	time.Sleep(50 * time.Millisecond)
+	s.Stop()
+}
+
+func TestSpinner_DoubleStart(t *testing.T) {
+	s := New("Loading...")
+	s.Start()
+	s.Start() // second start should be a no-op
+	s.Stop()
+}
+
+func TestSpinner_DoubleStop(t *testing.T) {
+	s := New("Loading...")
+	s.Start()
+	s.Stop()
+	s.Stop() // second stop should be a no-op
+}
+
+func TestSpinner_UpdateMessage(t *testing.T) {
+	s := New("Loading...")
+	s.Start()
+	s.UpdateMessage("Still loading...")
+	s.Stop()
+}
+
+func TestSpinner_StopWithoutStart(t *testing.T) {
+	s := New("Loading...")
+	s.Stop() // should not panic
+}

--- a/internal/repl/readline_adapter.go
+++ b/internal/repl/readline_adapter.go
@@ -1,0 +1,57 @@
+package repl
+
+import (
+	"strings"
+
+	"github.com/chzyer/readline"
+)
+
+// Verify interface compliance at compile time.
+var _ readline.AutoCompleter = (*ReadlineCompleter)(nil)
+
+// ReadlineCompleter adapts a Completer to readline's AutoCompleter interface.
+type ReadlineCompleter struct {
+	completer *Completer
+}
+
+// NewReadlineCompleter wraps a Completer for use with readline.
+func NewReadlineCompleter(c *Completer) *ReadlineCompleter {
+	return &ReadlineCompleter{completer: c}
+}
+
+// Do implements readline.AutoCompleter. It returns completion candidates
+// and the length of the word prefix being completed.
+func (rc *ReadlineCompleter) Do(line []rune, pos int) ([][]rune, int) {
+	// Use only text up to cursor position
+	input := string(line[:pos])
+
+	candidates := rc.completer.Complete(input)
+	if len(candidates) == 0 {
+		return nil, 0
+	}
+
+	// Determine the word being completed (last token before cursor)
+	lastSpace := strings.LastIndex(input, " ")
+	prefix := ""
+	if lastSpace >= 0 && lastSpace < len(input)-1 {
+		prefix = input[lastSpace+1:]
+	} else if lastSpace < 0 {
+		prefix = input
+	}
+	// If input ends with space, prefix is empty (completing new word)
+
+	prefixLen := len([]rune(prefix))
+
+	result := make([][]rune, 0, len(candidates))
+	for _, c := range candidates {
+		// Return only the suffix after the shared prefix
+		if strings.HasPrefix(c, prefix) {
+			suffix := c[len(prefix):]
+			result = append(result, []rune(suffix+" "))
+		} else {
+			result = append(result, []rune(c+" "))
+		}
+	}
+
+	return result, prefixLen
+}

--- a/internal/repl/readline_adapter_test.go
+++ b/internal/repl/readline_adapter_test.go
@@ -1,0 +1,96 @@
+package repl
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestRootCmd() *cobra.Command {
+	root := &cobra.Command{Use: "canvas"}
+
+	courses := &cobra.Command{Use: "courses", Short: "Manage courses"}
+	courses.AddCommand(&cobra.Command{Use: "list", Short: "List courses"})
+	courses.AddCommand(&cobra.Command{Use: "get", Short: "Get a course"})
+
+	config := &cobra.Command{Use: "config", Short: "Manage config"}
+	config.AddCommand(&cobra.Command{Use: "set", Short: "Set config"})
+
+	root.AddCommand(courses, config)
+	return root
+}
+
+func TestReadlineCompleter_Do(t *testing.T) {
+	root := newTestRootCmd()
+	completer := NewCompleter(root)
+	rc := NewReadlineCompleter(completer)
+
+	tests := []struct {
+		name        string
+		line        string
+		pos         int
+		wantResults bool
+		wantPrefLen int
+		description string
+	}{
+		{
+			name:        "complete from empty",
+			line:        "",
+			pos:         0,
+			wantResults: true,
+			wantPrefLen: 0,
+			description: "Should return top-level commands",
+		},
+		{
+			name:        "partial command",
+			line:        "co",
+			pos:         2,
+			wantResults: true,
+			wantPrefLen: 2,
+			description: "Should match courses and config",
+		},
+		{
+			name:        "subcommand after space",
+			line:        "courses ",
+			pos:         8,
+			wantResults: true,
+			wantPrefLen: 0,
+			description: "Should return subcommands of courses",
+		},
+		{
+			name:        "partial subcommand",
+			line:        "courses l",
+			pos:         9,
+			wantResults: true,
+			wantPrefLen: 1,
+			description: "Should match 'list'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, prefLen := rc.Do([]rune(tt.line), tt.pos)
+			if tt.wantResults && len(results) == 0 {
+				t.Errorf("expected results for %q but got none", tt.line)
+			}
+			if !tt.wantResults && len(results) > 0 {
+				t.Errorf("expected no results for %q but got %d", tt.line, len(results))
+			}
+			if prefLen != tt.wantPrefLen {
+				t.Errorf("prefixLen = %d, want %d", prefLen, tt.wantPrefLen)
+			}
+		})
+	}
+}
+
+func TestReadlineCompleter_InterfaceCompliance(t *testing.T) {
+	root := newTestRootCmd()
+	completer := NewCompleter(root)
+	rc := NewReadlineCompleter(completer)
+
+	// Verify that the interface is satisfied (compile-time check is in the source,
+	// but this is a runtime sanity check)
+	if rc == nil {
+		t.Fatal("expected non-nil ReadlineCompleter")
+	}
+}

--- a/internal/shellparse/shellparse.go
+++ b/internal/shellparse/shellparse.go
@@ -1,0 +1,38 @@
+package shellparse
+
+// Split splits a shell-like input string into arguments, respecting
+// double-quoted and single-quoted strings. Multiple consecutive spaces
+// are treated as a single delimiter. Quotes are consumed (not included
+// in the output).
+func Split(input string) []string {
+	var args []string
+	var current []byte
+	inQuote := false
+	quoteChar := byte(0)
+
+	for i := 0; i < len(input); i++ {
+		c := input[i]
+
+		switch {
+		case (c == '"' || c == '\'') && !inQuote:
+			inQuote = true
+			quoteChar = c
+		case inQuote && c == quoteChar:
+			inQuote = false
+			quoteChar = 0
+		case c == ' ' && !inQuote:
+			if len(current) > 0 {
+				args = append(args, string(current))
+				current = current[:0]
+			}
+		default:
+			current = append(current, c)
+		}
+	}
+
+	if len(current) > 0 {
+		args = append(args, string(current))
+	}
+
+	return args
+}

--- a/internal/shellparse/shellparse_test.go
+++ b/internal/shellparse/shellparse_test.go
@@ -1,0 +1,89 @@
+package shellparse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "simple words",
+			input: "courses list",
+			want:  []string{"courses", "list"},
+		},
+		{
+			name:  "double quoted argument",
+			input: `assignments create --name "Homework 1"`,
+			want:  []string{"assignments", "create", "--name", "Homework 1"},
+		},
+		{
+			name:  "single quoted argument",
+			input: `config set --value 'hello world'`,
+			want:  []string{"config", "set", "--value", "hello world"},
+		},
+		{
+			name:  "mixed quotes",
+			input: `search --name "some thing" --desc 'another thing'`,
+			want:  []string{"search", "--name", "some thing", "--desc", "another thing"},
+		},
+		{
+			name:  "multiple spaces",
+			input: "courses   list   --verbose",
+			want:  []string{"courses", "list", "--verbose"},
+		},
+		{
+			name:  "leading and trailing spaces",
+			input: "  courses list  ",
+			want:  []string{"courses", "list"},
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "only spaces",
+			input: "   ",
+			want:  nil,
+		},
+		{
+			name:  "empty quoted string produces argument",
+			input: `courses ""`,
+			want:  []string{"courses"},
+		},
+		{
+			name:  "adjacent quoted and unquoted",
+			input: `--name="hello world"`,
+			want:  []string{"--name=hello world"},
+		},
+		{
+			name:  "single word",
+			input: "help",
+			want:  []string{"help"},
+		},
+		{
+			name:  "quote inside other quote type",
+			input: `say "it's fine"`,
+			want:  []string{"say", "it's fine"},
+		},
+		{
+			name:  "double quote inside single quotes",
+			input: `say 'he said "hello"'`,
+			want:  []string{"say", `he said "hello"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Split(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Split(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -1,0 +1,46 @@
+package terminal
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	return term.IsTerminal(fd)
+}
+
+// IsStdoutTerminal returns true if stdout is a terminal.
+func IsStdoutTerminal() bool {
+	return IsTerminal(int(os.Stdout.Fd()))
+}
+
+// IsStderrTerminal returns true if stderr is a terminal.
+func IsStderrTerminal() bool {
+	return IsTerminal(int(os.Stderr.Fd()))
+}
+
+// IsStdinTerminal returns true if stdin is a terminal.
+func IsStdinTerminal() bool {
+	return IsTerminal(int(os.Stdin.Fd()))
+}
+
+// SupportsColor returns true if the terminal likely supports color output.
+// Checks stdout TTY and the NO_COLOR convention (https://no-color.org/).
+func SupportsColor() bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	return IsStdoutTerminal()
+}
+
+// Width returns the width of the terminal connected to stdout.
+// Returns 80 as a fallback if the width cannot be determined.
+func Width() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 {
+		return 80
+	}
+	return w
+}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,0 +1,24 @@
+package terminal
+
+import (
+	"testing"
+)
+
+func TestWidth(t *testing.T) {
+	w := Width()
+	if w <= 0 {
+		t.Errorf("Width() returned %d, expected > 0", w)
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	// Should not panic regardless of whether running in a terminal
+	_ = IsStdoutTerminal()
+	_ = IsStderrTerminal()
+	_ = IsStdinTerminal()
+}
+
+func TestSupportsColor(t *testing.T) {
+	// Should not panic
+	_ = SupportsColor()
+}

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
 )
 
 // State tracks update-related state
@@ -24,12 +26,12 @@ type StateManager struct {
 
 // NewStateManager creates a new StateManager
 func NewStateManager() (*StateManager, error) {
-	home, err := os.UserHomeDir()
+	configDir, err := config.GetConfigDir()
 	if err != nil {
 		return nil, err
 	}
 
-	statePath := filepath.Join(home, ".canvas-cli", "update-state.json")
+	statePath := filepath.Join(configDir, "update-state.json")
 	return &StateManager{statePath: statePath}, nil
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - Shell Completion: user-guide/shell-completion.md
     - Command Aliases: user-guide/aliases.md
     - Context Management: user-guide/context.md
+    - Best Practices: best-practices.md
   - Commands: commands/index.md
   - Tutorials:
     - tutorials/index.md


### PR DESCRIPTION
## Summary

- **Config path dedup**: Centralize all `~/.canvas-cli` path construction into `config.GetConfigDir()`, eliminating 13+ hardcoded paths across the codebase
- **Config caching**: Add thread-safe caching to `config.Load()` with `Reload()` and `ResetCache()` for tests
- **Doctor JSON**: Replace manual `fmt.Printf` JSON serialization with `encoding/json.MarshalIndent` for correctness
- **GlobalOptions struct**: Add `GlobalOptions` struct bridging root-level flag variables for incremental adoption
- **TTY detection**: Add `internal/terminal` package with `IsTerminal()`, `SupportsColor()`, `Width()` utilities
- **Quiet mode**: Add `--quiet`/`-q` persistent flag to suppress informational messages across all commands
- **Progress spinner**: Add TTY-aware animated spinner for long-running list operations (courses, users, enrollments, modules, submissions)
- **Signal handling**: Add `signal.NotifyContext` for SIGINT/SIGTERM with context propagation via `ExecuteContext()`
- **Shell parsing**: Add `internal/shellparse` for quote-aware argument splitting, used in REPL and alias expansion
- **REPL tab-completion**: Wire existing `Completer` into readline via `ReadlineCompleter` adapter
- **Best practices docs**: Add best practices documentation page

## Test plan

- [x] `make test` — all tests pass (including new tests for shellparse, terminal, spinner, readline adapter)
- [x] `make build` — binary builds cleanly
- [x] `make lint` — no lint warnings (golangci-lint, go vet, gofmt)
- [ ] `./bin/canvas --help` — verify `--quiet` flag appears
- [ ] `./bin/canvas courses list -o json --quiet` — no info messages, only JSON
- [ ] `./bin/canvas doctor --json` — valid JSON output (test with `| jq .`)
- [ ] `./bin/canvas shell` — tab completion works, quoted args work
- [ ] `./bin/canvas courses list` — spinner appears during fetch (TTY only)
- [ ] `Ctrl+C` during a long operation — graceful exit