### PR TITLE
fix: ensure --output json produces strict, parseable JSON

### DIFF
--- a/commands/admins.go
+++ b/commands/admins.go
@@ -423,15 +423,9 @@ func runAdminsList(ctx context.Context, client *api.Client, opts *options.Admins
 		return fmt.Errorf("failed to list admins: %w", err)
 	}
 
-	if len(admins) == 0 {
-		fmt.Println("No admins found")
-		logger.LogCommandComplete(ctx, "admins.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d admins:\n\n", len(admins))
 	logger.LogCommandComplete(ctx, "admins.list", len(admins))
-	return formatOutput(admins, nil)
+	return formatEmptyOrOutput(admins, "No admins found")
 }
 
 func runAdminsAdd(ctx context.Context, client *api.Client, opts *options.AdminsAddOptions) error {
@@ -521,15 +515,9 @@ func runRolesList(ctx context.Context, client *api.Client, opts *options.RolesLi
 		return fmt.Errorf("failed to list roles: %w", err)
 	}
 
-	if len(roles) == 0 {
-		fmt.Println("No roles found")
-		logger.LogCommandComplete(ctx, "roles.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d roles:\n\n", len(roles))
 	logger.LogCommandComplete(ctx, "roles.list", len(roles))
-	return formatOutput(roles, nil)
+	return formatEmptyOrOutput(roles, "No roles found")
 }
 
 func runRolesGet(ctx context.Context, client *api.Client, opts *options.RolesGetOptions) error {

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -106,7 +106,7 @@ func runAliasSet(ctx context.Context, opts *options.AliasSetOptions) error {
 	}
 
 	logger.LogCommandComplete(ctx, "alias.set", 1)
-	fmt.Printf("Alias %q set to: %s\n", opts.Name, opts.Expansion)
+	printInfo("Alias %q set to: %s\n", opts.Name, opts.Expansion)
 	return nil
 }
 
@@ -141,6 +141,10 @@ func runAliasList(ctx context.Context, opts *options.AliasListOptions) error {
 
 	aliases := cfg.ListAliases()
 	if len(aliases) == 0 {
+		if isStructuredOutput() {
+			logger.LogCommandComplete(ctx, "alias.list", 0)
+			return formatOutput([]struct{}{}, nil)
+		}
 		fmt.Println("No aliases configured.")
 		fmt.Println("\nCreate one with: canvas alias set <name> <command>")
 		logger.LogCommandComplete(ctx, "alias.list", 0)
@@ -211,7 +215,7 @@ func runAliasDelete(ctx context.Context, opts *options.AliasDeleteOptions) error
 	}
 
 	logger.LogCommandComplete(ctx, "alias.delete", 1)
-	fmt.Printf("Alias %q deleted.\n", opts.Name)
+	printInfo("Alias %q deleted.\n", opts.Name)
 	return nil
 }
 

--- a/commands/analytics.go
+++ b/commands/analytics.go
@@ -255,15 +255,9 @@ func runAnalyticsActivity(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to get course activity: %w", err)
 	}
 
-	if len(activity) == 0 {
-		fmt.Println("No activity data found")
-		logger.LogCommandComplete(ctx, "analytics.activity", 0)
-		return nil
-	}
-
 	printVerbose("Course activity data (%d days):\n\n", len(activity))
 	logger.LogCommandComplete(ctx, "analytics.activity", len(activity))
-	return formatOutput(activity, nil)
+	return formatEmptyOrOutput(activity, "No activity data found")
 }
 
 func runAnalyticsAssignments(ctx context.Context, client *api.Client, opts *options.AnalyticsAssignmentsOptions) error {
@@ -282,15 +276,9 @@ func runAnalyticsAssignments(ctx context.Context, client *api.Client, opts *opti
 		return fmt.Errorf("failed to get assignment analytics: %w", err)
 	}
 
-	if len(assignments) == 0 {
-		fmt.Println("No assignment data found")
-		logger.LogCommandComplete(ctx, "analytics.assignments", 0)
-		return nil
-	}
-
 	printVerbose("Assignment analytics (%d assignments):\n\n", len(assignments))
 	logger.LogCommandComplete(ctx, "analytics.assignments", len(assignments))
-	return formatOutput(assignments, nil)
+	return formatEmptyOrOutput(assignments, "No assignment data found")
 }
 
 func runAnalyticsStudents(ctx context.Context, client *api.Client, opts *options.AnalyticsStudentsOptions) error {
@@ -314,15 +302,9 @@ func runAnalyticsStudents(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to get student summaries: %w", err)
 	}
 
-	if len(summaries) == 0 {
-		fmt.Println("No student data found")
-		logger.LogCommandComplete(ctx, "analytics.students", 0)
-		return nil
-	}
-
 	printVerbose("Student summaries (%d students):\n\n", len(summaries))
 	logger.LogCommandComplete(ctx, "analytics.students", len(summaries))
-	return formatOutput(summaries, nil)
+	return formatEmptyOrOutput(summaries, "No student data found")
 }
 
 func runAnalyticsUser(ctx context.Context, client *api.Client, opts *options.AnalyticsUserOptions) error {
@@ -346,13 +328,8 @@ func runAnalyticsUser(ctx context.Context, client *api.Client, opts *options.Ana
 			})
 			return fmt.Errorf("failed to get user activity: %w", err)
 		}
-		if len(activity) == 0 {
-			fmt.Println("No activity data found")
-			logger.LogCommandComplete(ctx, "analytics.user", 0)
-			return nil
-		}
 		logger.LogCommandComplete(ctx, "analytics.user", len(activity))
-		return formatOutput(activity, nil)
+		return formatEmptyOrOutput(activity, "No activity data found")
 
 	case "assignments":
 		assignments, err := service.GetUserAssignments(ctx, opts.CourseID, opts.UserID)
@@ -364,13 +341,8 @@ func runAnalyticsUser(ctx context.Context, client *api.Client, opts *options.Ana
 			})
 			return fmt.Errorf("failed to get user assignments: %w", err)
 		}
-		if len(assignments) == 0 {
-			fmt.Println("No assignment data found")
-			logger.LogCommandComplete(ctx, "analytics.user", 0)
-			return nil
-		}
 		logger.LogCommandComplete(ctx, "analytics.user", len(assignments))
-		return formatOutput(assignments, nil)
+		return formatEmptyOrOutput(assignments, "No assignment data found")
 
 	case "communication":
 		communication, err := service.GetUserCommunication(ctx, opts.CourseID, opts.UserID)
@@ -432,13 +404,8 @@ func runAnalyticsDepartment(ctx context.Context, client *api.Client, opts *optio
 			})
 			return fmt.Errorf("failed to get department activity: %w", err)
 		}
-		if len(activity) == 0 {
-			fmt.Println("No activity data found")
-			logger.LogCommandComplete(ctx, "analytics.department", 0)
-			return nil
-		}
 		logger.LogCommandComplete(ctx, "analytics.department", len(activity))
-		return formatOutput(activity, nil)
+		return formatEmptyOrOutput(activity, "No activity data found")
 
 	case "grades":
 		grades, err := service.GetDepartmentGrades(ctx, opts.AccountID, apiOpts)
@@ -449,13 +416,8 @@ func runAnalyticsDepartment(ctx context.Context, client *api.Client, opts *optio
 			})
 			return fmt.Errorf("failed to get department grades: %w", err)
 		}
-		if len(grades) == 0 {
-			fmt.Println("No grade data found")
-			logger.LogCommandComplete(ctx, "analytics.department", 0)
-			return nil
-		}
 		logger.LogCommandComplete(ctx, "analytics.department", len(grades))
-		return formatOutput(grades, nil)
+		return formatEmptyOrOutput(grades, "No grade data found")
 
 	default:
 		logger.LogCommandError(ctx, "analytics.department", fmt.Errorf("invalid analytics type"), map[string]interface{}{

--- a/commands/announcements.go
+++ b/commands/announcements.go
@@ -266,15 +266,9 @@ func runAnnouncementsList(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to list announcements: %w", err)
 	}
 
-	if len(announcements) == 0 {
-		fmt.Println("No announcements found")
-		logger.LogCommandComplete(ctx, "announcements.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d announcements:\n\n", len(announcements))
 	logger.LogCommandComplete(ctx, "announcements.list", len(announcements))
-	return formatOutput(announcements, nil)
+	return formatEmptyOrOutput(announcements, "No announcements found")
 }
 
 func runAnnouncementsGet(ctx context.Context, client *api.Client, opts *options.AnnouncementsGetOptions) error {

--- a/commands/assignments.go
+++ b/commands/assignments.go
@@ -458,6 +458,12 @@ func runAssignmentsCreate(ctx context.Context, client *api.Client, cmd *cobra.Co
 		return fmt.Errorf("failed to create assignment: %w", err)
 	}
 
+	logger.LogCommandComplete(ctx, "assignments.create", 1)
+
+	if isStructuredOutput() {
+		return formatOutput(assignment, nil)
+	}
+
 	printInfo("Assignment created successfully!\n")
 	printInfo("  ID: %d\n", assignment.ID)
 	printInfo("  Name: %s\n", assignment.Name)
@@ -471,7 +477,6 @@ func runAssignmentsCreate(ctx context.Context, client *api.Client, cmd *cobra.Co
 		printInfo("  Status: Unpublished\n")
 	}
 
-	logger.LogCommandComplete(ctx, "assignments.create", 1)
 	return nil
 }
 
@@ -588,6 +593,12 @@ func runAssignmentsUpdate(ctx context.Context, client *api.Client, cmd *cobra.Co
 		return fmt.Errorf("failed to update assignment: %w", err)
 	}
 
+	logger.LogCommandComplete(ctx, "assignments.update", 1)
+
+	if isStructuredOutput() {
+		return formatOutput(assignment, nil)
+	}
+
 	printInfo("Assignment updated successfully!\n")
 	printInfo("  ID: %d\n", assignment.ID)
 	printInfo("  Name: %s\n", assignment.Name)
@@ -601,7 +612,6 @@ func runAssignmentsUpdate(ctx context.Context, client *api.Client, cmd *cobra.Co
 		printInfo("  Status: Unpublished\n")
 	}
 
-	logger.LogCommandComplete(ctx, "assignments.update", 1)
 	return nil
 }
 

--- a/commands/blueprint.go
+++ b/commands/blueprint.go
@@ -382,15 +382,9 @@ func runBlueprintAssociationsList(ctx context.Context, client *api.Client, opts 
 		return fmt.Errorf("failed to list associated courses: %w", err)
 	}
 
-	if len(courses) == 0 {
-		fmt.Println("No associated courses found")
-		logger.LogCommandComplete(ctx, "blueprint.associations.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d associated courses:\n\n", len(courses))
 	logger.LogCommandComplete(ctx, "blueprint.associations.list", len(courses))
-	return formatOutput(courses, nil)
+	return formatEmptyOrOutput(courses, "No associated courses found")
 }
 
 func runBlueprintAssociationsAdd(ctx context.Context, client *api.Client, opts *options.BlueprintAssociationsAddOptions) error {
@@ -551,15 +545,9 @@ func runBlueprintMigrationsList(ctx context.Context, client *api.Client, opts *o
 		return fmt.Errorf("failed to list migrations: %w", err)
 	}
 
-	if len(migrations) == 0 {
-		fmt.Println("No migrations found")
-		logger.LogCommandComplete(ctx, "blueprint.migrations.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d migrations:\n\n", len(migrations))
 	logger.LogCommandComplete(ctx, "blueprint.migrations.list", len(migrations))
-	return formatOutput(migrations, nil)
+	return formatEmptyOrOutput(migrations, "No migrations found")
 }
 
 func runBlueprintMigrationsGet(ctx context.Context, client *api.Client, opts *options.BlueprintMigrationsGetOptions) error {

--- a/commands/calendar.go
+++ b/commands/calendar.go
@@ -339,15 +339,9 @@ func runCalendarList(ctx context.Context, client *api.Client, opts *options.Cale
 		return fmt.Errorf("failed to list calendar events: %w", err)
 	}
 
-	if len(events) == 0 {
-		fmt.Println("No calendar events found")
-		logger.LogCommandComplete(ctx, "calendar.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d calendar events:\n\n", len(events))
 	logger.LogCommandComplete(ctx, "calendar.list", len(events))
-	return formatOutput(events, nil)
+	return formatEmptyOrOutput(events, "No calendar events found")
 }
 
 func runCalendarGet(ctx context.Context, client *api.Client, opts *options.CalendarGetOptions) error {

--- a/commands/content_migrations.go
+++ b/commands/content_migrations.go
@@ -284,15 +284,9 @@ func runContentMigrationsList(ctx context.Context, client *api.Client, opts *opt
 		return fmt.Errorf("failed to list content migrations: %w", err)
 	}
 
-	if len(migrations) == 0 {
-		fmt.Println("No content migrations found")
-		logger.LogCommandComplete(ctx, "content_migrations.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d content migrations:\n\n", len(migrations))
 	logger.LogCommandComplete(ctx, "content_migrations.list", len(migrations))
-	return formatOutput(migrations, nil)
+	return formatEmptyOrOutput(migrations, "No content migrations found")
 }
 
 func runContentMigrationsGet(ctx context.Context, client *api.Client, opts *options.ContentMigrationsGetOptions) error {

--- a/commands/context.go
+++ b/commands/context.go
@@ -125,7 +125,7 @@ func runContextSet(ctx context.Context, opts *options.ContextSetOptions) error {
 	}
 
 	logger.LogCommandComplete(ctx, "context.set", 1)
-	fmt.Printf("Context %s set to %d\n", contextType, opts.ID)
+	printInfo("Context %s set to %d\n", contextType, opts.ID)
 	return nil
 }
 
@@ -159,6 +159,11 @@ func runContextShow(ctx context.Context, opts *options.ContextShowOptions) error
 	}
 
 	ctxVal := cfg.GetContext()
+
+	if isStructuredOutput() {
+		logger.LogCommandComplete(ctx, "context.show", 1)
+		return formatOutput(ctxVal, nil)
+	}
 
 	// Check if any context is set
 	if ctxVal.CourseID == 0 && ctxVal.AssignmentID == 0 && ctxVal.UserID == 0 && ctxVal.AccountID == 0 {
@@ -237,7 +242,7 @@ func runContextClear(ctx context.Context, opts *options.ContextClearOptions) err
 			return fmt.Errorf("failed to clear context: %w", err)
 		}
 		logger.LogCommandComplete(ctx, "context.clear", 1)
-		fmt.Println("Context cleared.")
+		printInfoln("Context cleared.")
 		return nil
 	}
 
@@ -266,7 +271,7 @@ func runContextClear(ctx context.Context, opts *options.ContextClearOptions) err
 	}
 
 	logger.LogCommandComplete(ctx, "context.clear", 1)
-	fmt.Printf("Context %s cleared.\n", contextType)
+	printInfo("Context %s cleared.\n", contextType)
 	return nil
 }
 

--- a/commands/conversations.go
+++ b/commands/conversations.go
@@ -486,15 +486,9 @@ func runConversationsList(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to list conversations: %w", err)
 	}
 
-	if len(conversations) == 0 {
-		fmt.Println("No conversations found")
-		logger.LogCommandComplete(ctx, "conversations.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d conversations:\n\n", len(conversations))
 	logger.LogCommandComplete(ctx, "conversations.list", len(conversations))
-	return formatOutput(conversations, nil)
+	return formatEmptyOrOutput(conversations, "No conversations found")
 }
 
 func runConversationsGet(ctx context.Context, client *api.Client, opts *options.ConversationsGetOptions) error {

--- a/commands/discussions.go
+++ b/commands/discussions.go
@@ -466,15 +466,9 @@ func runDiscussionsList(ctx context.Context, client *api.Client, opts *options.D
 		return fmt.Errorf("failed to list discussions: %w", err)
 	}
 
-	if len(topics) == 0 {
-		fmt.Println("No discussion topics found")
-		logger.LogCommandComplete(ctx, "discussions.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d discussion topics:\n\n", len(topics))
 	logger.LogCommandComplete(ctx, "discussions.list", len(topics))
-	return formatOutput(topics, nil)
+	return formatEmptyOrOutput(topics, "No discussion topics found")
 }
 
 func runDiscussionsGet(ctx context.Context, client *api.Client, opts *options.DiscussionsGetOptions) error {
@@ -639,15 +633,9 @@ func runDiscussionsEntries(ctx context.Context, client *api.Client, opts *option
 		return fmt.Errorf("failed to list entries: %w", err)
 	}
 
-	if len(entries) == 0 {
-		fmt.Println("No entries found")
-		logger.LogCommandComplete(ctx, "discussions.entries", 0)
-		return nil
-	}
-
 	printVerbose("Found %d entries:\n\n", len(entries))
 	logger.LogCommandComplete(ctx, "discussions.entries", len(entries))
-	return formatOutput(entries, nil)
+	return formatEmptyOrOutput(entries, "No entries found")
 }
 
 func runDiscussionsPost(ctx context.Context, client *api.Client, opts *options.DiscussionsPostOptions) error {

--- a/commands/doctor.go
+++ b/commands/doctor.go
@@ -84,7 +84,9 @@ func runDoctor(ctx context.Context, opts *options.DoctorOptions) error {
 	doctor := diagnostics.New(cfg, client)
 
 	// Run diagnostics
-	printInfoln("Running diagnostics...")
+	if !opts.JSON {
+		printInfoln("Running diagnostics...")
+	}
 	report, err := doctor.Run(ctx)
 	if err != nil {
 		logger.LogCommandError(ctx, "doctor", err, nil)

--- a/commands/external_tools.go
+++ b/commands/external_tools.go
@@ -348,15 +348,9 @@ func runExtToolsList(ctx context.Context, client *api.Client, cmd *cobra.Command
 		return fmt.Errorf("failed to list external tools: %w", err)
 	}
 
-	if len(tools) == 0 {
-		fmt.Println("No external tools found")
-		logger.LogCommandComplete(ctx, "external_tools.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d external tools:\n\n", len(tools))
 	logger.LogCommandComplete(ctx, "external_tools.list", len(tools))
-	return formatOutput(tools, nil)
+	return formatEmptyOrOutput(tools, "No external tools found")
 }
 
 func runExtToolsGet(ctx context.Context, client *api.Client, opts *options.ExternalToolsGetOptions) error {

--- a/commands/files.go
+++ b/commands/files.go
@@ -304,16 +304,9 @@ func runFilesList(ctx context.Context, client *api.Client, opts *options.FilesLi
 		return fmt.Errorf("failed to list files: %w", err)
 	}
 
-	if len(files) == 0 {
-		fmt.Println("No files found")
-		logger.LogCommandComplete(ctx, "files.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d files:\n\n", len(files))
-
 	logger.LogCommandComplete(ctx, "files.list", len(files))
-	return formatOutput(files, nil)
+	return formatEmptyOrOutput(files, "No files found")
 }
 
 func runFilesGet(ctx context.Context, client *api.Client, opts *options.FilesGetOptions) error {

--- a/commands/grades.go
+++ b/commands/grades.go
@@ -432,16 +432,9 @@ func runGradesHistory(ctx context.Context, client *api.Client, opts *options.Gra
 		return fmt.Errorf("failed to get gradebook history: %w", err)
 	}
 
-	if len(days) == 0 {
-		fmt.Println("No gradebook history found")
-		logger.LogCommandComplete(ctx, "grades.history", 0)
-		return nil
-	}
-
 	printVerbose("Found %d history days:\n\n", len(days))
-
 	logger.LogCommandComplete(ctx, "grades.history", len(days))
-	return formatOutput(days, nil)
+	return formatEmptyOrOutput(days, "No gradebook history found")
 }
 
 func runGradesFeed(ctx context.Context, client *api.Client, opts *options.GradesFeedOptions) error {
@@ -469,16 +462,9 @@ func runGradesFeed(ctx context.Context, client *api.Client, opts *options.Grades
 		return fmt.Errorf("failed to get gradebook feed: %w", err)
 	}
 
-	if len(entries) == 0 {
-		fmt.Println("No gradebook entries found")
-		logger.LogCommandComplete(ctx, "grades.feed", 0)
-		return nil
-	}
-
 	printVerbose("Found %d feed entries:\n\n", len(entries))
-
 	logger.LogCommandComplete(ctx, "grades.feed", len(entries))
-	return formatOutput(entries, nil)
+	return formatEmptyOrOutput(entries, "No gradebook entries found")
 }
 
 func runGradesColumnsList(ctx context.Context, client *api.Client, opts *options.GradesColumnsListOptions) error {
@@ -502,16 +488,9 @@ func runGradesColumnsList(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to list custom columns: %w", err)
 	}
 
-	if len(columns) == 0 {
-		fmt.Println("No custom columns found")
-		logger.LogCommandComplete(ctx, "grades.columns.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d custom columns:\n\n", len(columns))
-
 	logger.LogCommandComplete(ctx, "grades.columns.list", len(columns))
-	return formatOutput(columns, nil)
+	return formatEmptyOrOutput(columns, "No custom columns found")
 }
 
 func runGradesColumnsGet(ctx context.Context, client *api.Client, opts *options.GradesColumnsGetOptions) error {
@@ -665,16 +644,9 @@ func runGradesColumnsDataList(ctx context.Context, client *api.Client, opts *opt
 		return fmt.Errorf("failed to get column data: %w", err)
 	}
 
-	if len(data) == 0 {
-		fmt.Println("No column data found")
-		logger.LogCommandComplete(ctx, "grades.columns.data.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d data entries:\n\n", len(data))
-
 	logger.LogCommandComplete(ctx, "grades.columns.data.list", len(data))
-	return formatOutput(data, nil)
+	return formatEmptyOrOutput(data, "No column data found")
 }
 
 func runGradesColumnsDataSet(ctx context.Context, client *api.Client, opts *options.GradesColumnsDataSetOptions) error {
@@ -697,8 +669,6 @@ func runGradesColumnsDataSet(ctx context.Context, client *api.Client, opts *opti
 		return fmt.Errorf("failed to set column data: %w", err)
 	}
 
-	fmt.Printf("Column data set for user %d\n", datum.UserID)
-
 	logger.LogCommandComplete(ctx, "grades.columns.data.set", 1)
-	return formatOutput(datum, nil)
+	return formatSuccessOutput(datum, fmt.Sprintf("Column data set for user %d", datum.UserID))
 }

--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -220,25 +220,33 @@ func getConfig() (*config.Config, error) {
 	return config.Load()
 }
 
-// printVerbose prints a message only in verbose mode
+// printVerbose prints a message only in verbose mode.
+// Output goes to stderr to avoid contaminating structured output (JSON/YAML/CSV).
 func printVerbose(format string, args ...interface{}) {
 	if verbose {
-		fmt.Printf(format, args...)
+		fmt.Fprintf(os.Stderr, format, args...)
 	}
 }
 
-// printInfo prints an informational message unless --quiet is set.
+// isStructuredOutput returns true if the current output format is JSON, YAML, or CSV.
+// Use this to suppress human-readable messages that would contaminate structured output.
+func isStructuredOutput() bool {
+	format := output.FormatType(outputFormat)
+	return format == output.FormatJSON || format == output.FormatYAML || format == output.FormatCSV
+}
+
+// printInfo prints an informational message unless --quiet is set or structured output is active.
 // Use this for success messages and status output that should not appear
 // when the user is piping or scripting.
 func printInfo(format string, args ...interface{}) {
-	if !quiet {
+	if !quiet && !isStructuredOutput() {
 		fmt.Printf(format, args...)
 	}
 }
 
-// printInfoln prints an informational line unless --quiet is set.
+// printInfoln prints an informational line unless --quiet is set or structured output is active.
 func printInfoln(a ...interface{}) {
-	if !quiet {
+	if !quiet && !isStructuredOutput() {
 		fmt.Println(a...)
 	}
 }

--- a/commands/pages.go
+++ b/commands/pages.go
@@ -376,15 +376,9 @@ func runPagesList(ctx context.Context, client *api.Client, opts *options.PagesLi
 		return fmt.Errorf("failed to list pages: %w", err)
 	}
 
-	if len(pages) == 0 {
-		logger.LogCommandComplete(ctx, "pages.list", 0)
-		fmt.Println("No pages found")
-		return nil
-	}
-
 	printVerbose("Found %d pages:\n\n", len(pages))
 	logger.LogCommandComplete(ctx, "pages.list", len(pages))
-	return formatOutput(pages, nil)
+	return formatEmptyOrOutput(pages, "No pages found")
 }
 
 func runPagesGet(ctx context.Context, client *api.Client, opts *options.PagesGetOptions) error {
@@ -582,15 +576,9 @@ func runPagesRevisions(ctx context.Context, client *api.Client, opts *options.Pa
 		return fmt.Errorf("failed to list revisions: %w", err)
 	}
 
-	if len(revisions) == 0 {
-		logger.LogCommandComplete(ctx, "pages.revisions", 0)
-		fmt.Println("No revisions found")
-		return nil
-	}
-
 	printVerbose("Found %d revisions:\n\n", len(revisions))
 	logger.LogCommandComplete(ctx, "pages.revisions", len(revisions))
-	return formatOutput(revisions, nil)
+	return formatEmptyOrOutput(revisions, "No revisions found")
 }
 
 func runPagesRevert(ctx context.Context, client *api.Client, opts *options.PagesRevertOptions) error {

--- a/commands/peer_reviews.go
+++ b/commands/peer_reviews.go
@@ -175,15 +175,9 @@ func runPeerReviewsList(ctx context.Context, client *api.Client, opts *options.P
 		return fmt.Errorf("failed to list peer reviews: %w", err)
 	}
 
-	if len(reviews) == 0 {
-		fmt.Println("No peer reviews found")
-		logger.LogCommandComplete(ctx, "peer_reviews.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d peer reviews:\n\n", len(reviews))
 	logger.LogCommandComplete(ctx, "peer_reviews.list", len(reviews))
-	return formatOutput(reviews, nil)
+	return formatEmptyOrOutput(reviews, "No peer reviews found")
 }
 
 func runPeerReviewsCreate(ctx context.Context, client *api.Client, opts *options.PeerReviewsCreateOptions) error {
@@ -212,11 +206,8 @@ func runPeerReviewsCreate(ctx context.Context, client *api.Client, opts *options
 		return fmt.Errorf("failed to create peer review: %w", err)
 	}
 
-	fmt.Printf("Peer review created (ID: %d)\n", review.ID)
-	fmt.Printf("Assessor ID: %d\n", review.AssessorID)
-	fmt.Printf("State: %s\n", review.WorkflowState)
 	logger.LogCommandComplete(ctx, "peer_reviews.create", 1)
-	return nil
+	return formatSuccessOutput(review, fmt.Sprintf("Peer review created (ID: %d, Assessor: %d, State: %s)", review.ID, review.AssessorID, review.WorkflowState))
 }
 
 func runPeerReviewsDelete(ctx context.Context, client *api.Client, opts *options.PeerReviewsDeleteOptions) error {

--- a/commands/planner.go
+++ b/commands/planner.go
@@ -405,16 +405,9 @@ func runPlannerItems(ctx context.Context, client *api.Client, opts *options.Plan
 		return fmt.Errorf("failed to list planner items: %w", err)
 	}
 
-	if len(items) == 0 {
-		fmt.Println("No planner items found")
-		logger.LogCommandComplete(ctx, "planner.items", 0)
-		return nil
-	}
-
 	printVerbose("Found %d planner items:\n\n", len(items))
-
 	logger.LogCommandComplete(ctx, "planner.items", len(items))
-	return formatOutput(items, nil)
+	return formatEmptyOrOutput(items, "No planner items found")
 }
 
 func runPlannerNotesList(ctx context.Context, client *api.Client, opts *options.PlannerNotesListOptions) error {
@@ -439,16 +432,9 @@ func runPlannerNotesList(ctx context.Context, client *api.Client, opts *options.
 		return fmt.Errorf("failed to list planner notes: %w", err)
 	}
 
-	if len(notes) == 0 {
-		fmt.Println("No planner notes found")
-		logger.LogCommandComplete(ctx, "planner.notes.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d planner notes:\n\n", len(notes))
-
 	logger.LogCommandComplete(ctx, "planner.notes.list", len(notes))
-	return formatOutput(notes, nil)
+	return formatEmptyOrOutput(notes, "No planner notes found")
 }
 
 func runPlannerNotesGet(ctx context.Context, client *api.Client, opts *options.PlannerNotesGetOptions) error {
@@ -598,10 +584,8 @@ func runPlannerComplete(ctx context.Context, client *api.Client, opts *options.P
 		return fmt.Errorf("failed to mark as complete: %w", err)
 	}
 
-	fmt.Printf("Marked %s %d as complete!\n", override.PlannableType, override.PlannableID)
-
 	logger.LogCommandComplete(ctx, "planner.complete", 1)
-	return nil
+	return formatSuccessOutput(override, fmt.Sprintf("Marked %s %d as complete!", override.PlannableType, override.PlannableID))
 }
 
 func runPlannerDismiss(ctx context.Context, client *api.Client, opts *options.PlannerDismissOptions) error {
@@ -632,10 +616,8 @@ func runPlannerDismiss(ctx context.Context, client *api.Client, opts *options.Pl
 		return fmt.Errorf("failed to dismiss: %w", err)
 	}
 
-	fmt.Printf("Dismissed %s %d from planner\n", override.PlannableType, override.PlannableID)
-
 	logger.LogCommandComplete(ctx, "planner.dismiss", 1)
-	return nil
+	return formatSuccessOutput(override, fmt.Sprintf("Dismissed %s %d from planner", override.PlannableType, override.PlannableID))
 }
 
 func runPlannerOverrides(ctx context.Context, client *api.Client, opts *options.PlannerOverridesOptions) error {
@@ -661,14 +643,7 @@ func runPlannerOverrides(ctx context.Context, client *api.Client, opts *options.
 		return fmt.Errorf("failed to list overrides: %w", err)
 	}
 
-	if len(overrides) == 0 {
-		fmt.Println("No planner overrides found")
-		logger.LogCommandComplete(ctx, "planner.overrides", 0)
-		return nil
-	}
-
 	printVerbose("Found %d planner overrides:\n\n", len(overrides))
-
 	logger.LogCommandComplete(ctx, "planner.overrides", len(overrides))
-	return formatOutput(overrides, nil)
+	return formatEmptyOrOutput(overrides, "No planner overrides found")
 }

--- a/commands/rubrics.go
+++ b/commands/rubrics.go
@@ -320,15 +320,9 @@ func runRubricsList(ctx context.Context, client *api.Client, opts *options.Rubri
 		return fmt.Errorf("failed to list rubrics: %w", err)
 	}
 
-	if len(rubrics) == 0 {
-		fmt.Println("No rubrics found")
-		logger.LogCommandComplete(ctx, "rubrics.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d rubrics:\n\n", len(rubrics))
 	logger.LogCommandComplete(ctx, "rubrics.list", len(rubrics))
-	return formatOutput(rubrics, nil)
+	return formatEmptyOrOutput(rubrics, "No rubrics found")
 }
 
 func runRubricsGet(ctx context.Context, client *api.Client, opts *options.RubricsGetOptions) error {

--- a/commands/sis_imports.go
+++ b/commands/sis_imports.go
@@ -314,15 +314,9 @@ func runSISList(ctx context.Context, client *api.Client, opts *options.SISImport
 		return fmt.Errorf("failed to list SIS imports: %w", err)
 	}
 
-	if len(imports) == 0 {
-		fmt.Println("No SIS imports found")
-		logger.LogCommandComplete(ctx, "sis_imports.list", 0)
-		return nil
-	}
-
 	printVerbose("Found %d SIS imports:\n\n", len(imports))
 	logger.LogCommandComplete(ctx, "sis_imports.list", len(imports))
-	return formatOutput(imports, nil)
+	return formatEmptyOrOutput(imports, "No SIS imports found")
 }
 
 func runSISGet(ctx context.Context, client *api.Client, opts *options.SISImportsGetOptions) error {

--- a/commands/submissions.go
+++ b/commands/submissions.go
@@ -337,16 +337,9 @@ func runSubmissionsList(ctx context.Context, client *api.Client, opts *options.S
 		return fmt.Errorf("failed to list submissions: %w", err)
 	}
 
-	if len(submissions) == 0 {
-		logger.LogCommandComplete(ctx, "submissions.list", 0)
-		fmt.Println("No submissions found")
-		return nil
-	}
-
-	// Format and display submissions
 	printVerbose("Found %d submissions:\n\n", len(submissions))
 	logger.LogCommandComplete(ctx, "submissions.list", len(submissions))
-	return formatOutput(submissions, nil)
+	return formatEmptyOrOutput(submissions, "No submissions found")
 }
 
 func runSubmissionsGet(ctx context.Context, client *api.Client, opts *options.SubmissionsGetOptions) error {
@@ -439,10 +432,15 @@ func runSubmissionsGrade(ctx context.Context, client *api.Client, opts *options.
 		return fmt.Errorf("failed to grade submission: %w", err)
 	}
 
-	// Display success message
 	userName := "Unknown"
 	if submission.User != nil {
 		userName = submission.User.Name
+	}
+
+	logger.LogCommandComplete(ctx, "submissions.grade", 1)
+
+	if isStructuredOutput() {
+		return formatOutput(submission, nil)
 	}
 
 	printInfo("✅ Successfully graded submission for %s\n", userName)
@@ -465,7 +463,6 @@ func runSubmissionsGrade(ctx context.Context, client *api.Client, opts *options.
 		printInfo("   Graded: %s\n", submission.GradedAt.Format("2006-01-02 15:04"))
 	}
 
-	logger.LogCommandComplete(ctx, "submissions.grade", 1)
 	return nil
 }
 
@@ -508,17 +505,31 @@ func runSubmissionsBulkGrade(ctx context.Context, client *api.Client, opts *opti
 	printVerbose("Found %d grades in CSV file\n\n", len(grades))
 
 	if opts.DryRun {
-		fmt.Println("DRY RUN - No changes will be applied")
-		fmt.Println()
-		fmt.Println("The following grades would be applied:")
+		printInfoln("DRY RUN - No changes will be applied")
+		printInfoln()
+		printInfoln("The following grades would be applied:")
 		for i, grade := range grades {
-			fmt.Printf("%d. User %d, Assignment %d: Score=%s", i+1, grade.UserID, grade.AssignmentID, grade.Grade)
+			msg := fmt.Sprintf("%d. User %d, Assignment %d: Score=%s", i+1, grade.UserID, grade.AssignmentID, grade.Grade)
 			if grade.Comment != "" {
-				fmt.Printf(", Comment=%s", grade.Comment)
+				msg += fmt.Sprintf(", Comment=%s", grade.Comment)
 			}
-			fmt.Println()
+			printInfoln(msg)
 		}
 		logger.LogCommandComplete(ctx, "submissions.bulk-grade", 0)
+
+		if isStructuredOutput() {
+			type dryRunEntry struct {
+				UserID       int64  `json:"user_id"`
+				AssignmentID int64  `json:"assignment_id"`
+				Grade        string `json:"grade"`
+				Comment      string `json:"comment,omitempty"`
+			}
+			entries := make([]dryRunEntry, len(grades))
+			for i, g := range grades {
+				entries[i] = dryRunEntry{UserID: g.UserID, AssignmentID: g.AssignmentID, Grade: g.Grade, Comment: g.Comment}
+			}
+			return formatOutput(entries, nil)
+		}
 		return nil
 	}
 
@@ -528,7 +539,7 @@ func runSubmissionsBulkGrade(ctx context.Context, client *api.Client, opts *opti
 	var errors []string
 
 	for i, grade := range grades {
-		fmt.Printf("Processing %d/%d: User %d, Assignment %d...", i+1, len(grades), grade.UserID, grade.AssignmentID)
+		printInfo("Processing %d/%d: User %d, Assignment %d...", i+1, len(grades), grade.UserID, grade.AssignmentID)
 
 		// Build params
 		params := &api.GradeSubmissionParams{
@@ -544,14 +555,28 @@ func runSubmissionsBulkGrade(ctx context.Context, client *api.Client, opts *opti
 		// Grade submission
 		_, err = submissionsService.Grade(ctx, opts.CourseID, grade.AssignmentID, grade.UserID, params)
 		if err != nil {
-			fmt.Printf(" ❌ Error: %v\n", err)
+			printInfo(" ❌ Error: %v\n", err)
 			errorCount++
 			errors = append(errors, fmt.Sprintf("Row %d: %v", grade.Row, err))
 			continue
 		}
 
-		fmt.Printf(" ✅\n")
+		printInfo(" ✅\n")
 		successCount++
+	}
+
+	logger.LogCommandComplete(ctx, "submissions.bulk-grade", successCount)
+
+	if isStructuredOutput() {
+		summary := map[string]interface{}{
+			"total":   len(grades),
+			"success": successCount,
+			"errors":  errorCount,
+		}
+		if len(errors) > 0 {
+			summary["error_details"] = errors
+		}
+		return formatOutput(summary, nil)
 	}
 
 	// Print summary
@@ -568,8 +593,6 @@ func runSubmissionsBulkGrade(ctx context.Context, client *api.Client, opts *opti
 			fmt.Printf("  - %s\n", errMsg)
 		}
 	}
-
-	logger.LogCommandComplete(ctx, "submissions.bulk-grade", successCount)
 
 	if errorCount > 0 {
 		return fmt.Errorf("bulk grading completed with %d errors", errorCount)
@@ -605,15 +628,9 @@ func runSubmissionsComments(ctx context.Context, client *api.Client, opts *optio
 		return fmt.Errorf("failed to get submission: %w", err)
 	}
 
-	if len(submission.SubmissionComments) == 0 {
-		logger.LogCommandComplete(ctx, "submissions.comments", 0)
-		fmt.Println("No comments found for this submission")
-		return nil
-	}
-
 	printVerbose("Found %d comments:\n\n", len(submission.SubmissionComments))
 	logger.LogCommandComplete(ctx, "submissions.comments", len(submission.SubmissionComments))
-	return formatOutput(submission.SubmissionComments, nil)
+	return formatEmptyOrOutput(submission.SubmissionComments, "No comments found for this submission")
 }
 
 func runSubmissionsAddComment(ctx context.Context, client *api.Client, opts *options.SubmissionsAddCommentOptions) error {
@@ -651,8 +668,7 @@ func runSubmissionsAddComment(ctx context.Context, client *api.Client, opts *opt
 	}
 
 	logger.LogCommandComplete(ctx, "submissions.add-comment", 1)
-	printInfo("Comment added successfully to submission for user %d\n", submission.UserID)
-	return nil
+	return formatSuccessOutput(submission, fmt.Sprintf("Comment added successfully to submission for user %d", submission.UserID))
 }
 
 func runSubmissionsDeleteComment(ctx context.Context, client *api.Client, opts *options.SubmissionsDeleteCommentOptions) error {

--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -68,7 +69,7 @@ func (s *AutoRefreshTokenSource) Token() (*oauth2.Token, error) {
 	// Save the refreshed token
 	if err := s.store.Save(s.instanceName, newToken); err != nil {
 		// Log but don't fail - token is still valid for this session
-		fmt.Printf("Warning: failed to save refreshed token: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: failed to save refreshed token: %v\n", err)
 	}
 
 	s.token = newToken


### PR DESCRIPTION
## Summary

- **printVerbose** now writes to stderr instead of stdout, preventing contamination of structured output
- **22 commands** fixed: empty results now output `[]` for JSON/YAML/CSV instead of text like "No X found"
- **printInfo/printInfoln** automatically suppressed when `--output json/yaml/csv` is active
- **Mutating commands** (assignments create/update, submissions grade/bulk-grade, planner complete/dismiss, peer_reviews create) now output structured data for JSON format
- **doctor --json** no longer prints "Running diagnostics..." before JSON
- **context show --output json** outputs the context object instead of formatted text
- **Token refresh warning** moved to stderr
- Added `isStructuredOutput()` helper for format-aware output control
- Net reduction of 153 lines through consistent use of `formatEmptyOrOutput()` and `formatSuccessOutput()`

## Affected commands

All list commands that had `fmt.Println("No X found")` instead of `formatEmptyOrOutput()`:
announcements, discussions, files, content-migrations, submissions, admins, analytics (6 subcmds), calendar, peer-reviews, planner (3 subcmds), sis-imports, pages (2 subcmds), external-tools, conversations, blueprint (2 subcmds), grades (4 subcmds), rubrics

Mutating commands with unguarded success messages:
assignments create/update, submissions grade/bulk-grade/add-comment, planner complete/dismiss, peer-reviews create, context set/clear, alias set/delete

## Test plan

- [x] `make test` — all tests pass
- [x] `canvas courses list --output json` — valid JSON
- [x] `canvas announcements list --output json` (empty) — outputs `[]`
- [x] `canvas calendar list --output json` (empty) — outputs `[]`
- [x] `canvas context show --output json` — outputs context object
- [x] `canvas alias list --output json` (empty) — outputs `[]`
- [x] `canvas doctor --json` — valid JSON, no prefix text
- [x] `canvas courses list --output json --verbose` — valid JSON (verbose goes to stderr)
- [x] Table output unchanged for all commands