### PR TITLE
fix: detect Canvas soft errors in HTTP 200 responses (#24)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -495,6 +495,11 @@ func (c *Client) GetJSON(ctx context.Context, path string, result interface{}) e
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	// Check for Canvas soft errors (HTTP 200 with error body)
+	if err := checkSoftError(body); err != nil {
+		return err
+	}
+
 	// Decode the response
 	if err := json.Unmarshal(body, result); err != nil {
 		return err
@@ -522,8 +527,17 @@ func (c *Client) PostJSON(ctx context.Context, path string, body interface{}, re
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if err := checkSoftError(bodyBytes); err != nil {
+		return err
+	}
+
 	if result != nil {
-		return json.NewDecoder(resp.Body).Decode(result)
+		return json.Unmarshal(bodyBytes, result)
 	}
 
 	return nil
@@ -542,8 +556,17 @@ func (c *Client) PutJSON(ctx context.Context, path string, body interface{}, res
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if err := checkSoftError(bodyBytes); err != nil {
+		return err
+	}
+
 	if result != nil {
-		return json.NewDecoder(resp.Body).Decode(result)
+		return json.Unmarshal(bodyBytes, result)
 	}
 
 	return nil
@@ -572,12 +595,20 @@ func GetAllPagesGeneric[T any](c *Client, ctx context.Context, path string) ([]T
 			return nil, err
 		}
 
+		bodyBytes, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		if err := checkSoftError(bodyBytes); err != nil {
+			return nil, err
+		}
+
 		var pageResults []T
-		if err := json.NewDecoder(resp.Body).Decode(&pageResults); err != nil {
-			resp.Body.Close()
+		if err := json.Unmarshal(bodyBytes, &pageResults); err != nil {
 			return nil, fmt.Errorf("failed to decode response: %w", err)
 		}
-		resp.Body.Close()
 
 		allResults = append(allResults, pageResults...)
 
@@ -643,12 +674,20 @@ func (c *Client) GetAllPages(ctx context.Context, path string, result interface{
 			return err
 		}
 
+		bodyBytes, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		if err := checkSoftError(bodyBytes); err != nil {
+			return err
+		}
+
 		var pageResults []json.RawMessage
-		if err := json.NewDecoder(resp.Body).Decode(&pageResults); err != nil {
-			resp.Body.Close()
+		if err := json.Unmarshal(bodyBytes, &pageResults); err != nil {
 			return fmt.Errorf("failed to decode response: %w", err)
 		}
-		resp.Body.Close()
 
 		allResults = append(allResults, pageResults...)
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -597,6 +597,254 @@ func TestClient_UserAgent_Custom(t *testing.T) {
 	}
 }
 
+func TestClient_GetJSON_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		if r.URL.Path == "/api/v1/courses/123" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"message":"This environment is currently being updated.","status":"unauthorized"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	var course Course
+	err = client.GetJSON(ctx, "/api/v1/courses/123", &course)
+	if err == nil {
+		t.Fatal("expected error for soft error response, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_PostJSON_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"Maintenance in progress","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	var result map[string]interface{}
+	err = client.PostJSON(ctx, "/api/v1/accounts/1/courses", map[string]string{"name": "test"}, &result)
+	if err == nil {
+		t.Fatal("expected error for soft error response, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_PutJSON_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"Maintenance in progress","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	var result map[string]interface{}
+	err = client.PutJSON(ctx, "/api/v1/courses/123", map[string]string{"name": "test"}, &result)
+	if err == nil {
+		t.Fatal("expected error for soft error response, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_PostJSON_NilResult_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"Maintenance in progress","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	// Pass nil result — the P2 fix ensures we still check for soft errors
+	err = client.PostJSON(ctx, "/api/v1/modules/1/items/2/mark_read", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for soft error response with nil result, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_PutJSON_NilResult_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"Maintenance in progress","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	err = client.PutJSON(ctx, "/api/v1/some/endpoint", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for soft error response with nil result, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_GetAllPagesGeneric_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		// Return soft error instead of array
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"This environment is currently being updated.","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = GetAllPagesGeneric[Course](client, ctx, "/api/v1/courses")
+	if err == nil {
+		t.Fatal("expected error for soft error response in paginated request, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestClient_GetAllPages_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"This environment is currently being updated.","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	var courses []Course
+	err = client.GetAllPages(ctx, "/api/v1/courses", &courses)
+	if err == nil {
+		t.Fatal("expected error for soft error response in paginated request, got nil")
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
 // BenchmarkGetAllPages_Reflection benchmarks the old reflection-based GetAllPages method
 func BenchmarkGetAllPages_Reflection(b *testing.B) {
 	// Create test server with paginated data

--- a/internal/api/courses.go
+++ b/internal/api/courses.go
@@ -205,6 +205,10 @@ func (s *CoursesService) Create(ctx context.Context, params *CreateCourseParams)
 		return nil, err
 	}
 
+	if course.ID == 0 {
+		return nil, fmt.Errorf("course creation failed: Canvas returned no course ID (possible API error or maintenance mode)")
+	}
+
 	return NormalizeCourse(&course), nil
 }
 
@@ -285,6 +289,10 @@ func (s *CoursesService) Update(ctx context.Context, courseID int64, params *Upd
 	var course Course
 	if err := s.client.PutJSON(ctx, path, body, &course); err != nil {
 		return nil, err
+	}
+
+	if course.ID == 0 {
+		return nil, fmt.Errorf("course update failed: Canvas returned no course ID (possible API error or maintenance mode)")
 	}
 
 	return NormalizeCourse(&course), nil

--- a/internal/api/courses_test.go
+++ b/internal/api/courses_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -542,6 +543,127 @@ func TestCoursesService_Update_WithAllOptions(t *testing.T) {
 	}
 	if course.Name != "Updated Comprehensive Course" {
 		t.Errorf("Expected course name 'Updated Comprehensive Course', got %s", course.Name)
+	}
+}
+
+func TestCoursesService_Create_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			handleVersionDetection(w)
+			return
+		}
+
+		// Return HTTP 200 with Canvas error body (maintenance mode)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"This environment is currently being updated with a copy of the latest production data. Please check back later.","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	service := NewCoursesService(client)
+	ctx := context.Background()
+
+	params := &CreateCourseParams{
+		AccountID: 1,
+		Name:      "New Course",
+	}
+
+	course, err := service.Create(ctx, params)
+	if err == nil {
+		t.Fatalf("expected error, got course with ID %d", course.ID)
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestCoursesService_Update_SoftError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			handleVersionDetection(w)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":"This environment is currently being updated.","status":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	service := NewCoursesService(client)
+	ctx := context.Background()
+
+	params := &UpdateCourseParams{
+		Name: "Updated Name",
+	}
+
+	course, err := service.Update(ctx, 123, params)
+	if err == nil {
+		t.Fatalf("expected error, got course with ID %d", course.ID)
+	}
+
+	if !IsSoftError(err) {
+		t.Errorf("expected SoftError, got %T: %v", err, err)
+	}
+}
+
+func TestCoursesService_Create_ZeroID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			handleVersionDetection(w)
+			return
+		}
+
+		// Return a response with valid JSON but missing ID
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"name":"Some Course"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:        server.URL,
+		Token:          "test-token",
+		RequestsPerSec: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	service := NewCoursesService(client)
+	ctx := context.Background()
+
+	params := &CreateCourseParams{
+		AccountID: 1,
+		Name:      "Some Course",
+	}
+
+	_, err = service.Create(ctx, params)
+	if err == nil {
+		t.Fatal("expected error for zero ID course response")
+	}
+
+	if !strings.Contains(err.Error(), "no course ID") {
+		t.Errorf("expected error about missing course ID, got: %v", err)
 	}
 }
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -45,6 +45,49 @@ func ParseAPIError(resp *http.Response) error {
 	return &apiErr
 }
 
+// SoftError represents a Canvas API error returned with an HTTP 200 status code.
+// This occurs during maintenance windows, data refreshes, or other situations
+// where Canvas returns a success status code but the body contains an error message.
+type SoftError struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// Error implements the error interface
+func (e *SoftError) Error() string {
+	return fmt.Sprintf("Canvas API error: %s (status: %s)", e.Message, e.Status)
+}
+
+// checkSoftError inspects a response body for Canvas error patterns
+// that are returned with HTTP 200 status codes (e.g., maintenance mode).
+// Known patterns include: {"message":"...","status":"unauthorized"}
+func checkSoftError(body []byte) error {
+	var probe struct {
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	}
+
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return nil // not a JSON object — not a soft error
+	}
+
+	// Canvas uses "status" field with error-like values in soft error responses
+	if probe.Message != "" && probe.Status != "" && probe.Status != "ok" {
+		return &SoftError{
+			Status:  probe.Status,
+			Message: probe.Message,
+		}
+	}
+
+	return nil
+}
+
+// IsSoftError checks if the error is a Canvas soft error (HTTP 200 with error body)
+func IsSoftError(err error) bool {
+	var softErr *SoftError
+	return errors.As(err, &softErr)
+}
+
 // IsRateLimitError checks if the error is a rate limit error
 // Uses errors.As to properly handle wrapped errors
 func IsRateLimitError(err error) bool {

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -277,6 +277,102 @@ func TestIsNotFoundError_NotAPIError(t *testing.T) {
 	}
 }
 
+func TestCheckSoftError_MaintenanceMode(t *testing.T) {
+	body := []byte(`{"message":"This environment is currently being updated with a copy of the latest production data. Please check back later.","status":"unauthorized"}`)
+
+	err := checkSoftError(body)
+	if err == nil {
+		t.Fatal("expected soft error, got nil")
+	}
+
+	softErr, ok := err.(*SoftError)
+	if !ok {
+		t.Fatalf("expected *SoftError, got %T", err)
+	}
+
+	if softErr.Status != "unauthorized" {
+		t.Errorf("expected status 'unauthorized', got %q", softErr.Status)
+	}
+
+	if !strings.Contains(softErr.Message, "currently being updated") {
+		t.Errorf("expected message about maintenance, got %q", softErr.Message)
+	}
+}
+
+func TestCheckSoftError_ValidResponse(t *testing.T) {
+	body := []byte(`{"id":123,"name":"Test Course"}`)
+
+	err := checkSoftError(body)
+	if err != nil {
+		t.Errorf("expected no error for valid response, got %v", err)
+	}
+}
+
+func TestCheckSoftError_ArrayResponse(t *testing.T) {
+	body := []byte(`[{"id":1},{"id":2}]`)
+
+	err := checkSoftError(body)
+	if err != nil {
+		t.Errorf("expected no error for array response, got %v", err)
+	}
+}
+
+func TestCheckSoftError_StatusOk(t *testing.T) {
+	body := []byte(`{"message":"success","status":"ok"}`)
+
+	err := checkSoftError(body)
+	if err != nil {
+		t.Errorf("expected no error for status 'ok', got %v", err)
+	}
+}
+
+func TestCheckSoftError_EmptyFields(t *testing.T) {
+	body := []byte(`{"id":1,"status":"","message":""}`)
+
+	err := checkSoftError(body)
+	if err != nil {
+		t.Errorf("expected no error for empty status/message, got %v", err)
+	}
+}
+
+func TestCheckSoftError_InvalidJSON(t *testing.T) {
+	body := []byte(`not json at all`)
+
+	err := checkSoftError(body)
+	if err != nil {
+		t.Errorf("expected no error for invalid JSON, got %v", err)
+	}
+}
+
+func TestIsSoftError_True(t *testing.T) {
+	err := &SoftError{Status: "unauthorized", Message: "test"}
+	if !IsSoftError(err) {
+		t.Error("expected IsSoftError to return true for SoftError")
+	}
+}
+
+func TestIsSoftError_False(t *testing.T) {
+	err := &APIError{StatusCode: 401}
+	if IsSoftError(err) {
+		t.Error("expected IsSoftError to return false for APIError")
+	}
+}
+
+func TestSoftError_ErrorMessage(t *testing.T) {
+	err := &SoftError{
+		Status:  "unauthorized",
+		Message: "Environment is being updated",
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "Environment is being updated") {
+		t.Errorf("expected error message to contain the message, got %q", msg)
+	}
+	if !strings.Contains(msg, "unauthorized") {
+		t.Errorf("expected error message to contain the status, got %q", msg)
+	}
+}
+
 func TestAPIError_Error(t *testing.T) {
 	apiErr := &APIError{
 		StatusCode: http.StatusNotFound,


### PR DESCRIPTION
## Summary

Fixes #24. Canvas returns HTTP 200 with error payloads during maintenance windows and data refreshes (e.g., `{"message":"This environment is currently being updated...","status":"unauthorized"}`). Previously the CLI silently succeeded on these responses and returned zero-valued structs — `canvas courses create` would print `Course created successfully (ID: 0)` even though nothing was created.

## Changes

- Added `SoftError` type and `checkSoftError` helper (`internal/api/errors.go`) that inspects response bodies for Canvas error patterns in HTTP 200 responses.
- Applied the check across all JSON helpers in `internal/api/client.go`:
  - `GetJSON` — single-object reads
  - `PostJSON` / `PutJSON` — both with result decoding and nil-result paths (e.g., `ModulesService.MarkItemRead`, `EnrollmentsService.Accept`)
  - `GetAllPagesGeneric` / `GetAllPages` — paginated list reads
- Added `IsSoftError(err)` helper for error-type checking.
- Added post-deserialization validation in `CoursesService.Create` and `CoursesService.Update` as defense-in-depth (returns error when Canvas returns a response missing the course ID).

## Test plan

- [x] `go test ./internal/api/... -count=1` passes
- [x] `go test ./... -count=1` — full suite passes
- [x] Pre-commit hook (gofmt, golangci-lint, go vet, short tests) passes
- [x] New tests cover: `checkSoftError` edge cases, `GetJSON`/`PostJSON`/`PutJSON`/`GetAllPages`/`GetAllPagesGeneric` soft-error paths, `PostJSON`/`PutJSON` nil-result soft-error paths, and `CoursesService.Create`/`Update` with maintenance-mode and zero-ID responses.