### PR TITLE
docs: improve MCP setup and auth/env documentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,12 +50,6 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
-    # SA5011 in tests is frequently triggered by t.Fatal/t.FailNow control flow.
-    # Keep the check enabled for production code while reducing test noise.
-    - path: _test\.go
-      text: "SA5011"
-      linters:
-        - staticcheck
 
 output:
   formats:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,12 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
+    # SA5011 in tests is frequently triggered by t.Fatal/t.FailNow control flow.
+    # Keep the check enabled for production code while reducing test noise.
+    - path: _test\.go
+      text: "SA5011"
+      linters:
+        - staticcheck
 
 output:
   formats:

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Sensitive flags (`--show-token`, `--config`) are automatically excluded from MCP
 
 > **Note for `go install` users**: MCP support requires Go 1.25+ due to the [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk) dependency. Homebrew and binary downloads are not affected by this requirement.
 
+For full setup (Claude Desktop, Claude Code CLI, Cursor, VS Code, OpenCode, Codex), auth precedence, and troubleshooting, see:
+
+- [MCP Integration Guide](https://jjuanrivvera.github.io/canvas-cli/user-guide/mcp/)
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/commands/internal/logging/logger_test.go
+++ b/commands/internal/logging/logger_test.go
@@ -26,6 +26,7 @@ func TestNewCommandLogger(t *testing.T) {
 			logger := NewCommandLogger(tt.debug)
 			if logger == nil {
 				t.Fatal("NewCommandLogger() returned nil")
+				return
 			}
 			if logger.logger == nil {
 				t.Error("NewCommandLogger() logger field is nil")

--- a/commands/root_flags_test.go
+++ b/commands/root_flags_test.go
@@ -6,6 +6,7 @@ func TestRootQuietFlagHasNoShorthand(t *testing.T) {
 	flag := rootCmd.PersistentFlags().Lookup("quiet")
 	if flag == nil {
 		t.Fatal("expected quiet flag to exist on root command")
+		return
 	}
 
 	if flag.Shorthand != "" {
@@ -17,6 +18,7 @@ func TestAPIQueryFlagKeepsQShorthand(t *testing.T) {
 	flag := apiCmd.Flags().Lookup("query")
 	if flag == nil {
 		t.Fatal("expected query flag to exist on api command")
+		return
 	}
 
 	if flag.Shorthand != "q" {

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -170,7 +170,7 @@ graph LR
 
 | Component | Technology |
 |-----------|------------|
-| Language | Go 1.21+ |
+| Language | Go 1.25+ |
 | CLI Framework | [Cobra](https://github.com/spf13/cobra) |
 | Configuration | [Viper](https://github.com/spf13/viper) |
 | OAuth | golang.org/x/oauth2 |

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Canvas CLI! This document provide
 
 ### Prerequisites
 
-- Go 1.21 or later
+- Go 1.25 or later
 - Git
 - Make (optional, but recommended)
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -6,7 +6,7 @@ Resources for contributing to Canvas CLI development.
 
 Canvas CLI is built with:
 
-- **Go 1.21+** - Primary language
+- **Go 1.25+** - Primary language
 - **Cobra** - CLI framework
 - **Viper** - Configuration management
 
@@ -36,7 +36,7 @@ Canvas CLI is built with:
 
 ### Prerequisites
 
-- Go 1.21 or later
+- Go 1.25 or later
 - Git
 - Make (optional but recommended)
 

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -395,6 +395,7 @@ canvas auth login --instance https://canvas.instructure.com --verbose
 ## Next Steps
 
 After authentication:
+- [MCP Integration](../user-guide/mcp.md) - Use the same auth setup through MCP clients
 - [Command Reference](../commands/index.md) - Learn available commands
 - [Tutorials](../tutorials/index.md) - See common use cases
 - Test your setup: `canvas courses list`

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -51,6 +51,6 @@ Canvas CLI is a command-line interface for interacting with Canvas LMS. It provi
 
 ## Requirements
 
-- **Go 1.21+** (if installing from source)
+- **Go 1.25+** (if installing from source)
 - **Canvas LMS** account with API access
 - **API Token** or OAuth credentials

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ This guide covers all the ways to install Canvas CLI on your system.
 
 - **Operating Systems**: macOS, Linux, Windows
 - **Architecture**: amd64, arm64
-- **Go Version** (if building from source): 1.21 or later
+- **Go Version** (if building from source): 1.25 or later
 
 ## Installation Methods
 
@@ -43,6 +43,10 @@ go install github.com/jjuanrivvera/canvas-cli/cmd/canvas@v1.0.0
 # Verify installation
 canvas version
 ```
+
+!!! note "MCP + go install"
+    MCP support (`canvas mcp ...`) requires Go `1.25+` when installing with `go install`.
+    Homebrew and release binaries are not affected by local Go version.
 
 ### Method 3: Download Binary (All Platforms)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -98,5 +98,6 @@ Canvas CLI supports multiple output formats:
 ## Next Steps
 
 - [User Guide](../user-guide/index.md) - Learn more about configuration and features
+- [MCP Integration](../user-guide/mcp.md) - Connect Canvas CLI to AI clients via MCP
 - [Command Reference](../commands/index.md) - Complete command documentation
 - [Tutorials](../tutorials/index.md) - Step-by-step guides for common tasks

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 **A powerful command-line interface for Canvas LMS**
 
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Release](https://img.shields.io/github/v/release/jjuanrivvera/canvas-cli)](https://github.com/jjuanrivvera/canvas-cli/releases)
 
@@ -18,6 +18,7 @@
 - **Course Synchronization** - Sync content between Canvas instances
 - **Intelligent Caching** - Fast responses with automatic cache invalidation
 - **Secure Authentication** - OAuth 2.0 with PKCE flow
+- **MCP Integration** - Use Canvas CLI as an MCP server for AI coding assistants
 
 ## Quick Start
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -6,8 +6,9 @@ Canvas CLI can be configured using environment variables.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CANVAS_INSTANCE` | Canvas instance URL | From config |
+| `CANVAS_URL` | Canvas instance URL (env auth mode) | From config |
 | `CANVAS_TOKEN` | API access token | From config/keyring |
+| `CANVAS_REQUESTS_PER_SEC` | Request rate limit for env auth mode | `5.0` |
 | `CANVAS_OUTPUT` | Default output format | `table` |
 | `CANVAS_NO_CACHE` | Disable response caching | `false` |
 
@@ -26,7 +27,7 @@ CANVAS_OUTPUT=json canvas courses list
 Set for the current shell session:
 
 ```bash
-export CANVAS_INSTANCE=https://canvas.example.com
+export CANVAS_URL=https://canvas.example.com
 export CANVAS_TOKEN=your-api-token
 canvas courses list
 ```
@@ -37,23 +38,24 @@ Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
 # Canvas CLI configuration
-export CANVAS_INSTANCE=https://canvas.example.com
+export CANVAS_URL=https://canvas.example.com
 export CANVAS_TOKEN=your-api-token
 export CANVAS_OUTPUT=json
 ```
 
 ## Variable Details
 
-### CANVAS_INSTANCE
+### CANVAS_URL
 
 The Canvas LMS instance URL.
 
 ```bash
-export CANVAS_INSTANCE=https://canvas.instructure.com
+export CANVAS_URL=https://canvas.instructure.com
 ```
 
 !!! note "Priority"
-    Command-line `--instance` flag takes precedence over environment variable.
+    When both `CANVAS_URL` and `CANVAS_TOKEN` are set, CLI commands use env authentication directly.
+    In that mode, `--instance` and `default_instance` are not used.
 
 ### CANVAS_TOKEN
 
@@ -61,6 +63,14 @@ Canvas API access token. Generate from Canvas Account Settings.
 
 ```bash
 export CANVAS_TOKEN=7~AbCdEfGhIjKlMnOpQrStUvWxYz123456789
+```
+
+### CANVAS_REQUESTS_PER_SEC
+
+Request rate limit used when env auth mode is active.
+
+```bash
+export CANVAS_REQUESTS_PER_SEC=10.0
 ```
 
 !!! warning "Security"
@@ -96,10 +106,14 @@ export CANVAS_NO_CACHE=true
 
 Configuration is applied in this order (highest precedence first):
 
-1. Command-line flags (`--instance`, `--output`, etc.)
-2. Environment variables
-3. Configuration file (`~/.canvas-cli/config.yaml`)
+1. If both `CANVAS_URL` and `CANVAS_TOKEN` are set, env auth mode is used
+2. Otherwise, command-line flags (`--instance`, `--output`, etc.)
+3. Otherwise, configuration file (`~/.canvas-cli/config.yaml`)
 4. Built-in defaults
+
+!!! note "MCP clients"
+    This same precedence applies to MCP tool calls, because MCP executes the same command logic.
+    Each MCP client runs its own server process and therefore may have different environment variables.
 
 ## Example Configurations
 
@@ -107,7 +121,7 @@ Configuration is applied in this order (highest precedence first):
 
 ```bash
 # Use sandbox instance
-export CANVAS_INSTANCE=https://canvas-sandbox.example.com
+export CANVAS_URL=https://canvas-sandbox.example.com
 export CANVAS_TOKEN=sandbox-token
 export CANVAS_NO_CACHE=true
 ```
@@ -117,7 +131,7 @@ export CANVAS_NO_CACHE=true
 ```yaml
 # GitHub Actions example
 env:
-  CANVAS_INSTANCE: ${{ secrets.CANVAS_URL }}
+  CANVAS_URL: ${{ secrets.CANVAS_URL }}
   CANVAS_TOKEN: ${{ secrets.CANVAS_TOKEN }}
   CANVAS_OUTPUT: json
 ```
@@ -127,12 +141,12 @@ env:
 ```bash
 # Function to switch instances
 canvas-prod() {
-  export CANVAS_INSTANCE=https://canvas.example.com
+  export CANVAS_URL=https://canvas.example.com
   export CANVAS_TOKEN=$CANVAS_PROD_TOKEN
 }
 
 canvas-sandbox() {
-  export CANVAS_INSTANCE=https://canvas-sandbox.example.com
+  export CANVAS_URL=https://canvas-sandbox.example.com
   export CANVAS_TOKEN=$CANVAS_SANDBOX_TOKEN
 }
 ```
@@ -143,7 +157,7 @@ canvas-sandbox() {
 
 1. Verify the variable is set:
    ```bash
-   echo $CANVAS_INSTANCE
+   echo $CANVAS_URL
    ```
 
 2. Check for typos in variable names

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -30,6 +30,14 @@ Learn how to configure and use Canvas CLI effectively.
 
     [:octicons-arrow-right-24: Shell Completion](shell-completion.md)
 
+-   :material-robot-outline:{ .lg .middle } **MCP Integration**
+
+    ---
+
+    Connect Canvas CLI as an MCP server for Claude, Cursor, VS Code, OpenCode, and Codex
+
+    [:octicons-arrow-right-24: MCP Guide](mcp.md)
+
 -   :material-link-variant:{ .lg .middle } **Command Aliases**
 
     ---

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -1,0 +1,262 @@
+# MCP Integration
+
+Use Canvas CLI as a Model Context Protocol (MCP) server so AI clients can call Canvas tools directly.
+
+Canvas CLI exposes each command as an MCP tool (for example `canvas_courses_list`, `canvas_assignments_get`, `canvas_version`).
+
+## What You Get
+
+- One MCP server with the same behavior as the normal CLI
+- 250+ typed tools generated from command flags and args
+- Support for local stdio clients and HTTP streaming mode
+- Built-in editor helpers for Claude Desktop, Cursor, and VS Code
+
+## Install Path Notes
+
+Use an absolute binary path in MCP client configs.
+
+Common paths:
+
+- Homebrew (Apple Silicon macOS): `/opt/homebrew/bin/canvas`
+- Homebrew (Intel macOS / many Linux setups): `/usr/local/bin/canvas`
+- Manual binary install: wherever you placed `canvas` in `PATH`
+
+Quick check:
+
+```bash
+which canvas
+canvas version
+```
+
+## Requirements
+
+- Canvas CLI `v1.8.0+` recommended
+- If installed with `go install`, use Go `1.25+`
+- Valid Canvas auth using either:
+  - `canvas auth login` (OAuth), or
+  - `canvas auth token set`, or
+  - `CANVAS_URL` + `CANVAS_TOKEN` environment variables
+
+## Quick Start
+
+```bash
+# 1) Check MCP commands
+canvas mcp --help
+
+# 2) Export tool schemas and verify discovery
+canvas mcp tools
+
+# 3) Configure one client (examples below), then restart the client
+```
+
+After setup, ask your AI client to run `canvas_version`.
+
+## Transport Modes
+
+### STDIO (recommended for local clients)
+
+```bash
+canvas mcp start
+```
+
+Use this for Claude Code, Cursor, VS Code, OpenCode, and Codex local integration.
+
+### HTTP Stream
+
+```bash
+canvas mcp stream --host 127.0.0.1 --port 8080
+```
+
+Use this only when a client requires HTTP transport.
+
+!!! warning "Security"
+    `canvas mcp stream` does not add authentication by itself. Keep it on localhost, or place it behind an authenticated proxy/tunnel.
+
+## Client Setup
+
+### Claude Desktop
+
+Auto-configure with built-in helper:
+
+```bash
+canvas mcp claude enable
+canvas mcp claude list
+```
+
+Optional overrides:
+
+- `--server-name`
+- `--config-path`
+- `--env KEY=value`
+
+### Claude Code (CLI)
+
+Claude Code CLI uses its own MCP config. Add Canvas manually:
+
+```bash
+claude mcp add canvas /opt/homebrew/bin/canvas mcp start
+claude mcp list
+```
+
+### Cursor
+
+User-level setup:
+
+```bash
+canvas mcp cursor enable
+canvas mcp cursor list
+```
+
+Workspace setup (recommended per project):
+
+```bash
+canvas mcp cursor enable --workspace
+```
+
+This writes `.cursor/mcp.json` in your project.
+
+### VS Code
+
+User-level setup:
+
+```bash
+canvas mcp vscode enable
+```
+
+Workspace setup:
+
+```bash
+canvas mcp vscode enable --workspace
+```
+
+This writes `.vscode/mcp.json` in your project.
+
+### OpenCode
+
+Use OpenCode MCP management:
+
+```bash
+opencode mcp add
+opencode mcp list
+```
+
+When prompted, configure a local/stdio server with:
+
+- command: `/opt/homebrew/bin/canvas`
+- args: `mcp start`
+
+You can also define it directly under the `mcp` section in OpenCode config.
+
+### Codex CLI
+
+Add Canvas as a stdio MCP server:
+
+```bash
+codex mcp add canvas -- /opt/homebrew/bin/canvas mcp start
+codex mcp list
+```
+
+## Authentication and Environment Behavior
+
+MCP uses the same auth resolution path as normal CLI commands.
+
+Each AI client starts its own `canvas mcp start` process, so the server sees that specific client's environment variables.
+
+Auth/input precedence is:
+
+1. `CANVAS_URL` + `CANVAS_TOKEN` (if both are present)
+2. `flags.instance` (same as CLI `--instance`)
+3. `default_instance` from `~/.canvas-cli/config.yaml`
+
+So yes:
+
+- You can select instance per tool call with `flags.instance`.
+- Without instance flag, default instance is used.
+- If both `CANVAS_URL` and `CANVAS_TOKEN` exist in that process environment, they override instance/default.
+
+### Practical Example
+
+If Claude Code has `CANVAS_URL` and `CANVAS_TOKEN` exported, but Cursor does not:
+
+- Claude Code MCP calls will use env auth mode.
+- Cursor MCP calls will use `flags.instance` or `default_instance`.
+
+This is expected because each client owns its own MCP process environment.
+
+## Passing Flags in MCP Tool Calls
+
+Tool input follows generated schema. Example shape:
+
+```json
+{
+  "args": ["123"],
+  "flags": {
+    "instance": "staging",
+    "output": "json",
+    "quiet": true
+  }
+}
+```
+
+## Sensitive Flags
+
+For safety, inherited flags below are excluded from MCP exposure:
+
+- `--show-token`
+- `--config`
+
+## `--instance` in MCP Calls
+
+Use the same flag name under MCP `flags` as in CLI:
+
+```json
+{
+  "flags": {
+    "instance": "production"
+  }
+}
+```
+
+This behaves like:
+
+```bash
+canvas ... --instance production
+```
+
+## Verification Checklist
+
+```bash
+# Export and inspect available tools
+canvas mcp tools
+
+# Confirm your client sees configured MCP server
+# (use client-specific list command)
+
+# In client chat, run a harmless call first:
+# "Use tool canvas_version and show the output"
+```
+
+## Troubleshooting
+
+### Tool server not appearing in client
+
+- Restart the client after adding MCP server
+- Confirm command path is absolute (for example `/opt/homebrew/bin/canvas`)
+- Run `canvas mcp tools` to verify server-side tool discovery
+
+### Using wrong Canvas environment
+
+- Check if client process has `CANVAS_URL` and `CANVAS_TOKEN` set
+- If yes, those override `flags.instance` / default instance logic
+- If no, pass `flags.instance` explicitly or update `default_instance`
+
+### Unauthorized / invalid grant
+
+- Re-authenticate: `canvas auth login --instance <name>`
+- Or refresh token setup: `canvas auth token set <name> --token <token>`
+
+### HTTP stream cannot connect
+
+- Confirm host/port values
+- Keep `--host 127.0.0.1` for local-only usage
+- If remote access is needed, add your own authenticated gateway layer

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -111,6 +111,7 @@ Workspace setup (recommended per project):
 
 ```bash
 canvas mcp cursor enable --workspace
+canvas mcp cursor list --workspace
 ```
 
 This writes `.cursor/mcp.json` in your project.
@@ -127,6 +128,7 @@ Workspace setup:
 
 ```bash
 canvas mcp vscode enable --workspace
+canvas mcp vscode list --workspace
 ```
 
 This writes `.vscode/mcp.json` in your project.

--- a/internal/api/assignment_groups_test.go
+++ b/internal/api/assignment_groups_test.go
@@ -424,6 +424,7 @@ func TestNewAssignmentGroupsService(t *testing.T) {
 	service := NewAssignmentGroupsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/assignments_test.go
+++ b/internal/api/assignments_test.go
@@ -353,6 +353,7 @@ func TestNewAssignmentsService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewAssignmentsService returned nil")
+		return
 	}
 	if service.client != client {
 		t.Error("NewAssignmentsService did not set client correctly")

--- a/internal/api/calendar_test.go
+++ b/internal/api/calendar_test.go
@@ -412,6 +412,7 @@ func TestNewCalendarService(t *testing.T) {
 	service := NewCalendarService(client)
 	if service == nil {
 		t.Fatal("Expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("Expected service client to match input client")

--- a/internal/api/conversations_test.go
+++ b/internal/api/conversations_test.go
@@ -556,6 +556,7 @@ func TestNewConversationsService(t *testing.T) {
 	service := NewConversationsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/courses_test.go
+++ b/internal/api/courses_test.go
@@ -302,6 +302,7 @@ func TestNewCoursesService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewCoursesService returned nil")
+		return
 	}
 	if service.client != client {
 		t.Error("NewCoursesService did not set client correctly")

--- a/internal/api/discussions_test.go
+++ b/internal/api/discussions_test.go
@@ -476,6 +476,7 @@ func TestNewDiscussionsService(t *testing.T) {
 	service := NewDiscussionsService(client)
 	if service == nil {
 		t.Fatal("Expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("Expected service client to match input client")
@@ -487,6 +488,7 @@ func TestNewAnnouncementsService(t *testing.T) {
 	service := NewAnnouncementsService(client)
 	if service == nil {
 		t.Fatal("Expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("Expected service client to match input client")

--- a/internal/api/enrollments_test.go
+++ b/internal/api/enrollments_test.go
@@ -367,6 +367,7 @@ func TestNewEnrollmentsService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewEnrollmentsService returned nil")
+		return
 	}
 	if service.client != client {
 		t.Error("NewEnrollmentsService did not set client correctly")

--- a/internal/api/external_tools_test.go
+++ b/internal/api/external_tools_test.go
@@ -279,6 +279,7 @@ func TestExternalToolsService_DeleteFromCourse(t *testing.T) {
 
 	if tool == nil {
 		t.Fatal("Expected tool, got nil")
+		return
 	}
 
 	if tool.ID != 456 {

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -17,6 +17,7 @@ func TestNewFilesService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewFilesService returned nil")
+		return
 	}
 	if service.client != client {
 		t.Error("NewFilesService did not set client correctly")

--- a/internal/api/grades_test.go
+++ b/internal/api/grades_test.go
@@ -525,6 +525,7 @@ func TestNewGradesService(t *testing.T) {
 	service := NewGradesService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/groups_test.go
+++ b/internal/api/groups_test.go
@@ -634,6 +634,7 @@ func TestNewGroupsService(t *testing.T) {
 	service := NewGroupsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/modules_test.go
+++ b/internal/api/modules_test.go
@@ -606,6 +606,7 @@ func TestNewModulesService(t *testing.T) {
 	service := NewModulesService(client)
 	if service == nil {
 		t.Fatal("Expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("Expected service client to match input client")

--- a/internal/api/normalize_test.go
+++ b/internal/api/normalize_test.go
@@ -406,6 +406,7 @@ func TestNormalizeTerm(t *testing.T) {
 
 			if got == nil {
 				t.Fatal("NormalizeTerm() returned nil, want non-nil")
+				return
 			}
 
 			if got.ID != tt.want.ID {

--- a/internal/api/outcomes_test.go
+++ b/internal/api/outcomes_test.go
@@ -493,6 +493,7 @@ func TestNewOutcomesService(t *testing.T) {
 	service := NewOutcomesService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/overrides_test.go
+++ b/internal/api/overrides_test.go
@@ -407,6 +407,7 @@ func TestNewOverridesService(t *testing.T) {
 	service := NewOverridesService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/pages_test.go
+++ b/internal/api/pages_test.go
@@ -375,6 +375,7 @@ func TestNewPagesService(t *testing.T) {
 	service := NewPagesService(client)
 	if service == nil {
 		t.Fatal("Expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("Expected service client to match input client")

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -54,6 +54,7 @@ func TestParsePaginationLinks(t *testing.T) {
 			links := ParsePaginationLinks(resp)
 			if links == nil {
 				t.Fatal("expected non-nil pagination links")
+				return
 			}
 
 			if links.Next != tt.wantNext {

--- a/internal/api/planner_test.go
+++ b/internal/api/planner_test.go
@@ -511,6 +511,7 @@ func TestNewPlannerService(t *testing.T) {
 	service := NewPlannerService(client)
 	if service == nil {
 		t.Fatal("Expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("Expected service client to match input client")

--- a/internal/api/quiz_questions_test.go
+++ b/internal/api/quiz_questions_test.go
@@ -292,6 +292,7 @@ func TestNewQuizQuestionsService(t *testing.T) {
 	service := NewQuizQuestionsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/quiz_submissions_test.go
+++ b/internal/api/quiz_submissions_test.go
@@ -308,6 +308,7 @@ func TestNewQuizSubmissionsService(t *testing.T) {
 	service := NewQuizSubmissionsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/quizzes_test.go
+++ b/internal/api/quizzes_test.go
@@ -398,6 +398,7 @@ func TestNewQuizzesService(t *testing.T) {
 	service := NewQuizzesService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/retry_test.go
+++ b/internal/api/retry_test.go
@@ -13,6 +13,7 @@ func TestDefaultRetryPolicy(t *testing.T) {
 	policy := DefaultRetryPolicy()
 	if policy == nil {
 		t.Fatal("expected non-nil retry policy")
+		return
 	}
 
 	if policy.MaxRetries != 3 {

--- a/internal/api/rubrics_test.go
+++ b/internal/api/rubrics_test.go
@@ -416,6 +416,7 @@ func TestNewRubricsService(t *testing.T) {
 	service := NewRubricsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/sections_test.go
+++ b/internal/api/sections_test.go
@@ -481,6 +481,7 @@ func TestNewSectionsService(t *testing.T) {
 	service := NewSectionsService(client)
 	if service == nil {
 		t.Fatal("expected non-nil service")
+		return
 	}
 	if service.client != client {
 		t.Error("expected client to be set")

--- a/internal/api/submissions_test.go
+++ b/internal/api/submissions_test.go
@@ -362,6 +362,7 @@ func TestNewSubmissionsService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewSubmissionsService returned nil")
+		return
 	}
 	if service.client != client {
 		t.Error("NewSubmissionsService did not set client correctly")
@@ -1037,6 +1038,7 @@ func TestSubmissionsService_DeleteComment(t *testing.T) {
 
 	if comment == nil {
 		t.Fatal("expected comment to be returned")
+		return
 	}
 
 	if comment.ID != 999 {

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -273,6 +273,7 @@ func TestNewUsersService(t *testing.T) {
 
 	if service == nil {
 		t.Fatal("NewUsersService returned nil")
+		return
 	}
 	if service.client != client {
 		t.Error("NewUsersService did not set client correctly")

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -162,6 +162,7 @@ func TestDetectCanvasVersion(t *testing.T) {
 
 	if version == nil {
 		t.Fatal("expected non-nil version")
+		return
 	}
 
 	if version.Major != 2024 {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -297,6 +297,7 @@ func TestNewOAuthFlow(t *testing.T) {
 
 	if flow == nil {
 		t.Fatal("expected non-nil flow")
+		return
 	}
 
 	if flow.config.ClientID != "test-client-id" {
@@ -415,6 +416,7 @@ func TestFileTokenStore_Creation(t *testing.T) {
 	store := NewFileTokenStore(tempDir)
 	if store == nil {
 		t.Fatal("expected non-nil file store")
+		return
 	}
 	if store.configDir != tempDir {
 		t.Errorf("expected configDir '%s', got '%s'", tempDir, store.configDir)
@@ -426,6 +428,7 @@ func TestFallbackTokenStore_Creation(t *testing.T) {
 	store := NewFallbackTokenStore(tempDir)
 	if store == nil {
 		t.Fatal("expected non-nil fallback store")
+		return
 	}
 	if store.keyring == nil {
 		t.Error("expected keyring to be initialized")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -282,6 +282,7 @@ func TestLoad_NewConfig(t *testing.T) {
 	// Should return default config
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
+		return
 	}
 
 	if cfg.Instances == nil {

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -23,6 +23,7 @@ func TestNew(t *testing.T) {
 	doctor := New(cfg, nil)
 	if doctor == nil {
 		t.Fatal("expected non-nil doctor")
+		return
 	}
 
 	if doctor.config != cfg {
@@ -432,6 +433,7 @@ func TestRun_AllChecks(t *testing.T) {
 
 	if report == nil {
 		t.Fatal("expected non-nil report")
+		return
 	}
 
 	// Should have 7 checks

--- a/internal/repl/completer_test.go
+++ b/internal/repl/completer_test.go
@@ -50,6 +50,7 @@ func TestNewCompleter(t *testing.T) {
 
 	if completer == nil {
 		t.Fatal("expected non-nil completer")
+		return
 	}
 
 	if completer.rootCmd != rootCmd {

--- a/internal/repl/highlighter_test.go
+++ b/internal/repl/highlighter_test.go
@@ -10,6 +10,7 @@ func TestNewHighlighter(t *testing.T) {
 
 	if h == nil {
 		t.Fatal("expected non-nil highlighter")
+		return
 	}
 
 	if !h.enabled {

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -15,6 +15,7 @@ func TestNew(t *testing.T) {
 
 	if repl == nil {
 		t.Fatal("expected non-nil REPL")
+		return
 	}
 
 	if repl.rootCmd != rootCmd {

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -10,6 +10,7 @@ func TestNewSession(t *testing.T) {
 
 	if session == nil {
 		t.Fatal("expected non-nil session")
+		return
 	}
 
 	if session.Variables == nil {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -25,6 +25,7 @@ func TestNew(t *testing.T) {
 
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 
 	if !client.enabled {

--- a/internal/webhook/jwks_test.go
+++ b/internal/webhook/jwks_test.go
@@ -120,6 +120,7 @@ func TestJWKSet_GetKey(t *testing.T) {
 
 	if pubKey == nil {
 		t.Fatal("Expected public key, got nil")
+		return
 	}
 
 	// Verify it's the same key

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -24,6 +24,7 @@ func TestNew(t *testing.T) {
 
 	if listener == nil {
 		t.Fatal("expected non-nil listener")
+		return
 	}
 
 	if listener.addr != "localhost:8080" {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
   - User Guide:
     - user-guide/index.md
     - Configuration: user-guide/configuration.md
+    - MCP Integration: user-guide/mcp.md
     - Output Formats: user-guide/output-formats.md
     - Shell Completion: user-guide/shell-completion.md
     - Command Aliases: user-guide/aliases.md


### PR DESCRIPTION
## Summary
- add a dedicated MCP integration guide with clear setup for Claude Desktop, Claude Code, Cursor, VS Code, OpenCode, and Codex
- document MCP auth/environment precedence and troubleshooting, including how `flags.instance` behaves
- align related docs with current Go 1.25 baseline and correct environment variable references (`CANVAS_URL`/`CANVAS_TOKEN`)
- fix pre-commit lint failures at the source by updating tests to include explicit `return` after fatal nil checks (addresses `staticcheck` `SA5011`)

## Notes
- we intentionally removed the temporary lint suppression and fixed failing tests instead
- this keeps `staticcheck` active for test files and production code