### PR TITLE
ci: authenticate Codecov upload with CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
         uses: codecov/codecov-action@v4
         continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: jjuanrivvera/canvas-cli
           files: ./coverage.out
           fail_ci_if_error: false
 


### PR DESCRIPTION
Codecov uploads weren't authenticated (codecov-action@v4 requires a token), so coverage wasn't reaching Codecov.

- Pass \`token: \${{ secrets.CODECOV_TOKEN }}\` and \`slug\` to the upload step.
- The token is stored as the **CODECOV_TOKEN** repository secret; only the secret reference is committed.

This PR's own CI run will be the first authenticated upload, which also activates the Codecov project.