### PR TITLE
fix: stop auth OAuth-flow tests from opening a real browser

### DIFF
--- a/internal/auth/main_test.go
+++ b/internal/auth/main_test.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain stubs the browser launcher for the entire auth test binary.
+//
+// Several OAuth-flow tests exercise Authenticate / startLocalServer, which call
+// openBrowser to launch the system browser. Left real, that spawns browser tabs
+// on the developer's machine on every `go test` (it only stayed quiet in CI
+// because xdg-open isn't installed on the Linux runner, so the best-effort
+// Start() failed silently). Replace browserOpener with a no-op so no auth test
+// opens a real browser; the few tests that specifically verify browserOpener
+// save and restore it themselves.
+func TestMain(m *testing.M) {
+	browserOpener = func(string) {}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
The OAuth-flow tests (Authenticate / startLocalServer) call openBrowser, which spawns browser tabs on a dev machine on every `go test ./internal/auth/...`. CI didn't catch it because xdg-open isn't installed on the Linux runner. Add a package-level `TestMain` that stubs `browserOpener` to a no-op for the whole auth test binary. Verified: full auth suite passes with no browser launched.