### PR TITLE
feat: add install.sh for one-line install

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,6 +132,11 @@ release:
 
     ### Installation
 
+    **Quick install (macOS/Linux)**
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/jjuanrivvera/canvas-cli/main/install.sh | sh
+    ```
+
     **Homebrew (macOS/Linux)**
     ```bash
     brew tap jjuanrivvera/canvas-cli
@@ -145,6 +150,11 @@ release:
 
     **Binary Download**
     Download the appropriate archive for your platform below.
+
+  # Ship a pinned copy of the install script with every release, alongside the
+  # always-current one on main (raw.githubusercontent.com/.../main/install.sh).
+  extra_files:
+    - glob: ./install.sh
 
 brews:
   - name: canvas-cli

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@
 
 ## Installation
 
+### Quick Install (macOS/Linux)
+
+Auto-detects your platform and verifies the checksum:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jjuanrivvera/canvas-cli/main/install.sh | sh
+```
+
 ### Homebrew (macOS/Linux)
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/jjuanrivvera/canvas-cli
 // the go directive but not a toolchain directive. Keep this on the latest
 // 1.25.x patch — the blocking govulncheck job fails on stdlib vulnerabilities
 // fixed in patch releases.
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/chzyer/readline v1.5.1

--- a/install.sh
+++ b/install.sh
@@ -1,145 +1,86 @@
-#!/usr/bin/env sh
-# install.sh — download the latest canvas release into a local bin dir.
+#!/bin/sh
+# canvas installer for macOS and Linux.
 #
-# Usage:
 #   curl -fsSL https://raw.githubusercontent.com/jjuanrivvera/canvas-cli/main/install.sh | sh
 #
-# Environment:
-#   CANVAS_VERSION       pin a version, e.g. "v1.10.0" (default: latest)
-#   CANVAS_INSTALL_DIR   install location (default: $HOME/.local/bin)
-#   NO_COLOR             disable colored output
-
+# Downloads the release archive matching your OS/arch, verifies its SHA-256 against the
+# release checksums.txt, and installs the binary. Configure via env vars:
+#   CANVAS_VERSION=v1.2.3   pin a version (default: the latest release)
+#   INSTALL_DIR=/usr/local/bin        install location (default; falls back to ~/.local/bin)
+#
+# Windows: use Scoop (see the README). This installer is for macOS and Linux.
 set -eu
 
-# --- configuration (per project) ---------------------------------------------
-REPO="jjuanrivvera/canvas-cli"         # GitHub <owner>/<repo>
-PROJECT="canvas-cli"                   # release asset prefix (goreleaser project_name)
-BINARY="canvas"                        # installed binary (name inside the archive)
-VERSION_IN_NAME=0                      # 1 if the asset filename embeds the version
-ARCH_AMD64="x86_64"                    # token used for x86_64 hosts in asset names
-VERSION="${CANVAS_VERSION:-latest}"
-INSTALL_DIR="${CANVAS_INSTALL_DIR:-$HOME/.local/bin}"
-# ------------------------------------------------------------------------------
+# --- per-tool configuration (the only lines cliwright templates per CLI) ---
+REPO="jjuanrivvera/canvas-cli"
+BINARY="canvas"
+VERSION="${CANVAS_VERSION:-}"
 
-if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
-  C_RESET=$(printf '\033[0m'); C_BOLD=$(printf '\033[1m'); C_DIM=$(printf '\033[2m')
-  C_CYAN=$(printf '\033[36m'); C_GREEN=$(printf '\033[32m')
-  C_YELLOW=$(printf '\033[33m'); C_RED=$(printf '\033[31m')
-else
-  C_RESET=''; C_BOLD=''; C_DIM=''; C_CYAN=''; C_GREEN=''; C_YELLOW=''; C_RED=''
-fi
-step() { printf '  %s→%s %s\n' "$C_CYAN" "$C_RESET" "$*"; }
-ok()   { printf '  %s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
-warn() { printf '  %s!%s %s\n' "$C_YELLOW" "$C_RESET" "$*"; }
-err()  { printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
-has()  { command -v "$1" >/dev/null 2>&1; }
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 
-# --- detect platform ----------------------------------------------------------
-case "$(uname -s)" in
-  Darwin) os=darwin ;;
-  Linux)  os=linux ;;
-  *) err "unsupported OS: $(uname -s) (Windows users: download from https://github.com/$REPO/releases)" ;;
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v tar  >/dev/null 2>&1 || die "tar is required"
+if command -v sha256sum >/dev/null 2>&1; then shacmd="sha256sum"
+elif command -v shasum  >/dev/null 2>&1; then shacmd="shasum -a 256"
+else die "need sha256sum or shasum to verify the download"; fi
+
+# --- detect platform (goreleaser naming: lowercase os, amd64/arm64) ---
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux | darwin) ;;
+  *) die "unsupported OS: $os (this installer covers Linux and macOS; use 'go install' otherwise)" ;;
 esac
-case "$(uname -m)" in
-  x86_64|amd64)  arch="$ARCH_AMD64" ;;
-  arm64|aarch64) arch="arm64" ;;
-  *) err "unsupported architecture: $(uname -m)" ;;
-esac
-step "Detected ${os}/${arch}"
-
-# --- resolve version (latest by default) --------------------------------------
-if [ "$VERSION" = "latest" ]; then
-  VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
-    "https://github.com/$REPO/releases/latest" 2>/dev/null \
-    | sed -n 's|.*/tag/\(v[^/]*\).*|\1|p')
-  [ -n "$VERSION" ] || err "could not resolve the latest version (check network)"
-fi
-case "$VERSION" in v*) ;; *) VERSION="v$VERSION" ;; esac
-ver_clean="${VERSION#v}"
-step "Installing ${C_BOLD}${PROJECT} ${VERSION}${C_RESET}"
-
-# --- build asset name + base URL ----------------------------------------------
-if [ "$VERSION_IN_NAME" = "1" ]; then
-  asset="${PROJECT}_${ver_clean}_${os}_${arch}.tar.gz"
-else
-  asset="${PROJECT}_${os}_${arch}.tar.gz"
-fi
-base="https://github.com/$REPO/releases/download/$VERSION"
-
-tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
-
-# --- download -----------------------------------------------------------------
-step "Downloading ${asset}"
-curl -fsSL "$base/$asset" -o "$tmp/$asset" \
-  || err "failed to download $base/$asset (no release asset for ${os}/${arch}?)"
-curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt" \
-  || err "failed to download checksums.txt; refusing to install without verification"
-
-# --- verify sha256 (required) -------------------------------------------------
-expected=$(grep " ${asset}\$" "$tmp/checksums.txt" | awk '{print $1}')
-[ -n "$expected" ] || err "${asset} not listed in checksums.txt; refusing to install"
-if has sha256sum; then
-  actual=$(sha256sum "$tmp/$asset" | awk '{print $1}')
-elif has shasum; then
-  actual=$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')
-else
-  err "no sha256 tool found; install sha256sum or shasum and retry"
-fi
-[ "$expected" = "$actual" ] || err "checksum mismatch (expected=${expected} got=${actual})"
-step "Verified checksum"
-
-# --- verify cosign signature (optional, only if cosign is installed) ----------
-if has cosign; then
-  identity="^https://github.com/${REPO}/\.github/workflows/.+@refs/tags/"
-  issuer="https://token.actions.githubusercontent.com"
-  verify_checksums() {
-    cosign verify-blob "$@" \
-      --certificate-identity-regexp "$identity" --certificate-oidc-issuer "$issuer" \
-      "$tmp/checksums.txt" >/dev/null 2>&1
-  }
-  if curl -fsSL "$base/checksums.txt.cosign.bundle" -o "$tmp/cosign.bundle" 2>/dev/null; then
-    if verify_checksums --bundle "$tmp/cosign.bundle"; then
-      step "Verified cosign signature"
-    else
-      err "cosign signature verification failed"
-    fi
-  elif curl -fsSL "$base/checksums.txt.pem" -o "$tmp/checksums.pem" 2>/dev/null \
-    && curl -fsSL "$base/checksums.txt.sig" -o "$tmp/checksums.sig" 2>/dev/null; then
-    if verify_checksums --certificate "$tmp/checksums.pem" --signature "$tmp/checksums.sig"; then
-      step "Verified cosign signature"
-    else
-      err "cosign signature verification failed"
-    fi
-  else
-    warn "no cosign signature published for this release; skipping (checksum verified)"
-  fi
-fi
-
-# --- extract & install --------------------------------------------------------
-tar -xzf "$tmp/$asset" -C "$tmp"
-[ -f "$tmp/$BINARY" ] || err "archive did not contain a '$BINARY' binary"
-mkdir -p "$INSTALL_DIR"
-if has install; then
-  install -m 0755 "$tmp/$BINARY" "$INSTALL_DIR/$BINARY"
-else
-  mv "$tmp/$BINARY" "$INSTALL_DIR/$BINARY"
-  chmod +x "$INSTALL_DIR/$BINARY"
-fi
-ok "Installed ${C_BOLD}${BINARY} ${VERSION}${C_RESET} to ${INSTALL_DIR}/${BINARY}"
-
-# --- PATH hint ----------------------------------------------------------------
-case ":$PATH:" in
-  *":$INSTALL_DIR:"*) ;;
-  *)
-    printf '\n'
-    warn "${INSTALL_DIR} is not on your PATH"
-    printf '    add this to your shell profile (~/.zshrc, ~/.bashrc, ...):\n'
-    # shellcheck disable=SC2016  # literal $PATH is intentional
-    printf '      %sexport PATH="%s:$PATH"%s\n' "$C_DIM" "$INSTALL_DIR" "$C_RESET"
-    ;;
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64"; archre="(amd64|x86_64)" ;;
+  arm64 | aarch64) arch="arm64"; archre="(arm64|aarch64)" ;;
+  *) die "unsupported architecture: $arch" ;;
 esac
 
-printf '\n  %sNext steps%s\n' "$C_BOLD" "$C_RESET"
-printf '    %s%s --help%s\n' "$C_CYAN" "$BINARY" "$C_RESET"
-printf '    %s%s completion --help%s   set up shell completion\n\n' "$C_CYAN" "$BINARY" "$C_RESET"
+# --- resolve the version to install ---
+if [ -z "$VERSION" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name" *: *"([^"]+)".*/\1/')"
+  [ -n "$VERSION" ] || die "could not determine the latest release; set CANVAS_VERSION"
+fi
+
+base="https://github.com/${REPO}/releases/download/${VERSION}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# --- discover the exact archive from checksums.txt (naming-agnostic) ---
+curl -fsSL "${base}/checksums.txt" -o "${tmp}/checksums.txt" \
+  || die "could not download checksums.txt for ${VERSION}"
+archive="$(awk '{print $2}' "${tmp}/checksums.txt" | grep -iE "_${os}_${archre}\.tar\.gz$" | head -1)"
+[ -n "$archive" ] || die "no ${os}/${arch} archive in ${VERSION}"
+
+# --- download + verify the SHA-256 ---
+curl -fsSL "${base}/${archive}" -o "${tmp}/${archive}" || die "download failed: ${archive}"
+want="$(awk -v f="$archive" '$2 == f {print $1}' "${tmp}/checksums.txt")"
+got="$(cd "$tmp" && $shacmd "$archive" | awk '{print $1}')"
+[ -n "$want" ] || die "no checksum recorded for ${archive}"
+[ "$want" = "$got" ] || die "checksum mismatch for ${archive}"
+
+# --- extract + install ---
+tar -xzf "${tmp}/${archive}" -C "$tmp"
+[ -f "${tmp}/${BINARY}" ] || die "binary '${BINARY}' not found in the archive"
+chmod +x "${tmp}/${BINARY}"
+
+dir="${INSTALL_DIR:-/usr/local/bin}"
+if mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ]; then
+  mv "${tmp}/${BINARY}" "${dir}/${BINARY}"
+elif command -v sudo >/dev/null 2>&1 && [ -t 0 ]; then
+  printf 'installing to %s (needs sudo)\n' "$dir" >&2
+  sudo mv "${tmp}/${BINARY}" "${dir}/${BINARY}"
+else
+  dir="${HOME}/.local/bin"
+  mkdir -p "$dir"
+  mv "${tmp}/${BINARY}" "${dir}/${BINARY}"
+fi
+
+printf '%s %s installed to %s/%s\n' "$BINARY" "$VERSION" "$dir" "$BINARY"
+# shellcheck disable=SC2016  # the PATH hint is a literal string for the user to copy, not an expansion
+case ":${PATH}:" in
+  *":${dir}:"*) ;;
+  *) printf 'note: %s is not on your PATH — add:\n  export PATH="%s:$PATH"\n' "$dir" "$dir" >&2 ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env sh
+# install.sh — download the latest canvas release into a local bin dir.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/jjuanrivvera/canvas-cli/main/install.sh | sh
+#
+# Environment:
+#   CANVAS_VERSION       pin a version, e.g. "v1.10.0" (default: latest)
+#   CANVAS_INSTALL_DIR   install location (default: $HOME/.local/bin)
+#   NO_COLOR             disable colored output
+
+set -eu
+
+# --- configuration (per project) ---------------------------------------------
+REPO="jjuanrivvera/canvas-cli"         # GitHub <owner>/<repo>
+PROJECT="canvas-cli"                   # release asset prefix (goreleaser project_name)
+BINARY="canvas"                        # installed binary (name inside the archive)
+VERSION_IN_NAME=0                      # 1 if the asset filename embeds the version
+ARCH_AMD64="x86_64"                    # token used for x86_64 hosts in asset names
+VERSION="${CANVAS_VERSION:-latest}"
+INSTALL_DIR="${CANVAS_INSTALL_DIR:-$HOME/.local/bin}"
+# ------------------------------------------------------------------------------
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_RESET=$(printf '\033[0m'); C_BOLD=$(printf '\033[1m'); C_DIM=$(printf '\033[2m')
+  C_CYAN=$(printf '\033[36m'); C_GREEN=$(printf '\033[32m')
+  C_YELLOW=$(printf '\033[33m'); C_RED=$(printf '\033[31m')
+else
+  C_RESET=''; C_BOLD=''; C_DIM=''; C_CYAN=''; C_GREEN=''; C_YELLOW=''; C_RED=''
+fi
+step() { printf '  %s→%s %s\n' "$C_CYAN" "$C_RESET" "$*"; }
+ok()   { printf '  %s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn() { printf '  %s!%s %s\n' "$C_YELLOW" "$C_RESET" "$*"; }
+err()  { printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
+has()  { command -v "$1" >/dev/null 2>&1; }
+
+# --- detect platform ----------------------------------------------------------
+case "$(uname -s)" in
+  Darwin) os=darwin ;;
+  Linux)  os=linux ;;
+  *) err "unsupported OS: $(uname -s) (Windows users: download from https://github.com/$REPO/releases)" ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64)  arch="$ARCH_AMD64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) err "unsupported architecture: $(uname -m)" ;;
+esac
+step "Detected ${os}/${arch}"
+
+# --- resolve version (latest by default) --------------------------------------
+if [ "$VERSION" = "latest" ]; then
+  VERSION=$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/$REPO/releases/latest" 2>/dev/null \
+    | sed -n 's|.*/tag/\(v[^/]*\).*|\1|p')
+  [ -n "$VERSION" ] || err "could not resolve the latest version (check network)"
+fi
+case "$VERSION" in v*) ;; *) VERSION="v$VERSION" ;; esac
+ver_clean="${VERSION#v}"
+step "Installing ${C_BOLD}${PROJECT} ${VERSION}${C_RESET}"
+
+# --- build asset name + base URL ----------------------------------------------
+if [ "$VERSION_IN_NAME" = "1" ]; then
+  asset="${PROJECT}_${ver_clean}_${os}_${arch}.tar.gz"
+else
+  asset="${PROJECT}_${os}_${arch}.tar.gz"
+fi
+base="https://github.com/$REPO/releases/download/$VERSION"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# --- download -----------------------------------------------------------------
+step "Downloading ${asset}"
+curl -fsSL "$base/$asset" -o "$tmp/$asset" \
+  || err "failed to download $base/$asset (no release asset for ${os}/${arch}?)"
+curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt" \
+  || err "failed to download checksums.txt; refusing to install without verification"
+
+# --- verify sha256 (required) -------------------------------------------------
+expected=$(grep " ${asset}\$" "$tmp/checksums.txt" | awk '{print $1}')
+[ -n "$expected" ] || err "${asset} not listed in checksums.txt; refusing to install"
+if has sha256sum; then
+  actual=$(sha256sum "$tmp/$asset" | awk '{print $1}')
+elif has shasum; then
+  actual=$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')
+else
+  err "no sha256 tool found; install sha256sum or shasum and retry"
+fi
+[ "$expected" = "$actual" ] || err "checksum mismatch (expected=${expected} got=${actual})"
+step "Verified checksum"
+
+# --- verify cosign signature (optional, only if cosign is installed) ----------
+if has cosign; then
+  identity="^https://github.com/${REPO}/\.github/workflows/.+@refs/tags/"
+  issuer="https://token.actions.githubusercontent.com"
+  verify_checksums() {
+    cosign verify-blob "$@" \
+      --certificate-identity-regexp "$identity" --certificate-oidc-issuer "$issuer" \
+      "$tmp/checksums.txt" >/dev/null 2>&1
+  }
+  if curl -fsSL "$base/checksums.txt.cosign.bundle" -o "$tmp/cosign.bundle" 2>/dev/null; then
+    if verify_checksums --bundle "$tmp/cosign.bundle"; then
+      step "Verified cosign signature"
+    else
+      err "cosign signature verification failed"
+    fi
+  elif curl -fsSL "$base/checksums.txt.pem" -o "$tmp/checksums.pem" 2>/dev/null \
+    && curl -fsSL "$base/checksums.txt.sig" -o "$tmp/checksums.sig" 2>/dev/null; then
+    if verify_checksums --certificate "$tmp/checksums.pem" --signature "$tmp/checksums.sig"; then
+      step "Verified cosign signature"
+    else
+      err "cosign signature verification failed"
+    fi
+  else
+    warn "no cosign signature published for this release; skipping (checksum verified)"
+  fi
+fi
+
+# --- extract & install --------------------------------------------------------
+tar -xzf "$tmp/$asset" -C "$tmp"
+[ -f "$tmp/$BINARY" ] || err "archive did not contain a '$BINARY' binary"
+mkdir -p "$INSTALL_DIR"
+if has install; then
+  install -m 0755 "$tmp/$BINARY" "$INSTALL_DIR/$BINARY"
+else
+  mv "$tmp/$BINARY" "$INSTALL_DIR/$BINARY"
+  chmod +x "$INSTALL_DIR/$BINARY"
+fi
+ok "Installed ${C_BOLD}${BINARY} ${VERSION}${C_RESET} to ${INSTALL_DIR}/${BINARY}"
+
+# --- PATH hint ----------------------------------------------------------------
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    printf '\n'
+    warn "${INSTALL_DIR} is not on your PATH"
+    printf '    add this to your shell profile (~/.zshrc, ~/.bashrc, ...):\n'
+    # shellcheck disable=SC2016  # literal $PATH is intentional
+    printf '      %sexport PATH="%s:$PATH"%s\n' "$C_DIM" "$INSTALL_DIR" "$C_RESET"
+    ;;
+esac
+
+printf '\n  %sNext steps%s\n' "$C_BOLD" "$C_RESET"
+printf '    %s%s --help%s\n' "$C_CYAN" "$BINARY" "$C_RESET"
+printf '    %s%s completion --help%s   set up shell completion\n\n' "$C_CYAN" "$BINARY" "$C_RESET"


### PR DESCRIPTION
## Summary

Adds an `install.sh` so users can install on macOS/Linux with one line:

```bash
curl -fsSL https://raw.githubusercontent.com/jjuanrivvera/canvas-cli/main/install.sh | sh
```

It auto-detects OS/arch, resolves the latest release (or `CANVAS_VERSION`), downloads the matching archive, and verifies its **sha256 against `checksums.txt` (required — refuses to install otherwise)**. When `cosign` is installed it additionally verifies the checksums signature (auto-detecting the bundle vs pem+sig style) and hard-fails on a bad one; it skips that step cleanly when cosign isn't present. Installs to `~/.local/bin` (override with `CANVAS_INSTALL_DIR`) and prints a PATH hint.

## Changes
- `install.sh` — POSIX sh, shellcheck-clean.
- `.goreleaser.yaml` — ship a pinned copy with each release via `release.extra_files`.
- `README.md` — curl one-liner as the headline install method.

## Testing
- `shellcheck -s sh install.sh` clean; `goreleaser check` passes.
- End-to-end against `v1.10.0` on darwin/arm64: detect -> download -> sha256 verified -> cosign verified -> installed `canvas` runs.
- `.goreleaser.yaml` release header — added the curl line to the generated release notes too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Quick Install (macOS/Linux)” section with a one-line `curl | sh` command.
  * Installer auto-detects OS/architecture, downloads the correct release, and verifies SHA-256 checksums.
  * Installs the command-line tool to an appropriate location with sudo/fallback support and PATH guidance.
  * Release packages now include a pinned copy of the installer script for consistent installs.

* **Documentation**
  * Updated installation instructions in the README with the new quick install flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->