### PR TITLE
fix(agent): harden agent guard hook against bypasses

### DIFF
--- a/commands/agent.go
+++ b/commands/agent.go
@@ -103,6 +103,15 @@ var canvasBulkDestructivePaths = map[string]bool{
 	"sis-imports create": true,
 }
 
+// canvasWriteOverridePaths lists full CLI paths whose leaf name collides with
+// a read verb but which actually write. "sync assignments" ends in
+// "assignments" (a read verb via "analytics assignments") yet copies
+// assignments INTO the target course. Checked before the read allowlist so
+// the collision cannot silently allow a write.
+var canvasWriteOverridePaths = map[string]bool{
+	"sync assignments": true,
+}
+
 // canvasGuardCmd represents one classified Canvas operation.
 type canvasGuardCmd struct {
 	cli  string // CLI path without root, e.g. "courses delete"
@@ -300,6 +309,8 @@ func classifyCanvasCommands(root *cobra.Command) (read, writes, irreversible []c
 			switch {
 			case isCanvasIrreversibleVerb(sub.Name()):
 				irreversible = append(irreversible, gc)
+			case canvasWriteOverridePaths[cliPath]:
+				writes = append(writes, gc)
 			case isCanvasReadVerb(sub.Name()):
 				read = append(read, gc)
 			default:

--- a/commands/agent_hook_test.go
+++ b/commands/agent_hook_test.go
@@ -158,6 +158,42 @@ func TestCanvasHookScript_BashExecution(t *testing.T) {
 			wantDenied:  true,
 			description: "canvas submissions delete-comment must be denied (compound path with delete token)",
 		},
+		{
+			name:        "bash_relative_path_binary_denied",
+			payload:     bashPayload("./bin/canvas courses delete 5"),
+			wantDenied:  true,
+			description: "path-invoked binary ./bin/canvas courses delete must be denied",
+		},
+		{
+			name:        "bash_absolute_path_binary_denied",
+			payload:     bashPayload("/usr/local/bin/canvas courses delete 5"),
+			wantDenied:  true,
+			description: "path-invoked binary /usr/local/bin/canvas courses delete must be denied",
+		},
+		{
+			name:        "bash_absolute_path_api_delete_denied",
+			payload:     bashPayload("/usr/local/bin/canvas api DELETE /api/v1/courses/5"),
+			wantDenied:  true,
+			description: "path-invoked canvas api DELETE must be denied",
+		},
+		{
+			name:        "bash_other_binary_named_like_canvas_allowed",
+			payload:     bashPayload("mycanvas courses delete 5"),
+			wantDenied:  false,
+			description: "a different binary whose name merely ends in 'canvas' must NOT be denied",
+		},
+		{
+			name:        "bash_glued_separator_denied",
+			payload:     bashPayload("canvas favorites courses reset;true"),
+			wantDenied:  true,
+			description: "no-arg irreversible command with a shell separator glued to the verb must be denied",
+		},
+		{
+			name:        "bash_glued_pipe_denied",
+			payload:     bashPayload("canvas course-nicknames delete-all|cat"),
+			wantDenied:  true,
+			description: "irreversible command with a pipe glued to the verb must be denied",
+		},
 	}
 
 	for _, tc := range cases {
@@ -197,10 +233,22 @@ func TestCanvasHookScript_BashExecutionNoJq(t *testing.T) {
 		t.Fatalf("write hook: %v", err)
 	}
 
-	// Create an empty directory to shadow jq so it's "unavailable".
-	emptyPath := filepath.Join(tmpDir, "empty")
-	if err := os.Mkdir(emptyPath, 0o750); err != nil {
-		t.Fatalf("mkdir emptyPath: %v", err)
+	// Build a strict PATH containing ONLY the tools the hook needs, minus jq.
+	// (Merely prepending an empty dir does NOT hide jq — it stays reachable
+	// later in PATH and the no-jq branch never runs; that flaw previously
+	// masked a fail-open bug in this branch.)
+	strictPath := filepath.Join(tmpDir, "strictbin")
+	if err := os.Mkdir(strictPath, 0o750); err != nil {
+		t.Fatalf("mkdir strictPath: %v", err)
+	}
+	for _, tool := range []string{"cat", "tr", "grep", "sed", "printf"} {
+		p, err := exec.LookPath(tool)
+		if err != nil {
+			t.Skipf("required tool %s not found: %v", tool, err)
+		}
+		if err := os.Symlink(p, filepath.Join(strictPath, tool)); err != nil {
+			t.Fatalf("symlink %s: %v", tool, err)
+		}
 	}
 
 	bashPayload := func(command string) string {
@@ -213,12 +261,7 @@ func TestCanvasHookScript_BashExecutionNoJq(t *testing.T) {
 		return string(b)
 	}
 
-	// Build a PATH that keeps system tools (grep, sed, tr, etc.) but omits
-	// jq specifically by placing a wrapper dir that has no jq first.
-	// We keep the original PATH for all the POSIX utilities the hook uses.
-	origPath := os.Getenv("PATH")
-	// emptyPath prepended — jq not present there, but grep/sed/tr found later.
-	noJqPath := emptyPath + ":" + origPath
+	noJqPath := strictPath
 
 	runHookNoJq := func(t *testing.T, payload string) string {
 		t.Helper()
@@ -276,6 +319,15 @@ func TestCanvasHookScript_BashExecutionNoJq(t *testing.T) {
 		{
 			name:       "nojq_api_delete_denied",
 			payload:    bashPayload("canvas api DELETE /api/v1/courses/5"),
+			wantDenied: true,
+		},
+		{
+			// Regression: the compact JSON payload glues the command to its
+			// key ("command":"canvas ...). Without JSON-punctuation
+			// flattening the anchor can never match and the branch is
+			// silently fail-open.
+			name:       "nojq_glued_json_key_denied",
+			payload:    bashPayload("canvas users merge 1 2"),
 			wantDenied: true,
 		},
 	}

--- a/commands/agent_hosts.go
+++ b/commands/agent_hosts.go
@@ -168,8 +168,11 @@ func canvasHookScript(blocked []canvasGuardCmd) string {
 #
 # For each blocked cli-path P, we check whether the CLEANED command string
 # matches the anchored ERE:
-#   (^|[;&|(]+)[[:space:]]*canvas[[:space:]]+<P>([[:space:]]|$)
-# which ensures canvas+P appears at a command position.
+#   (^|[;&|([:space:]]+)([^[:space:]]*/)?canvas[[:space:]]+<P>([[:space:];&|)]|$)
+# which ensures canvas+P appears at a command position. The optional
+# ([^[:space:]]*/)? prefix also catches path-invoked binaries like
+# ./bin/canvas or /usr/local/bin/canvas; the trailing class accepts shell
+# separators so a glued "reset;true" still matches.
 #
 # The MCP branch is an exact set-membership check — no glob or regex.
 # The "canvas api" escape hatch is caught by method-position matching:
@@ -212,7 +215,9 @@ bash_is_blocked() {
     # only spaces need escaping to [[:space:]]+).
     local pat
     pat=$(printf '%s' "$p" | sed 's/ /[[:space:]]+/g')
-    if printf '%s' "$cleaned" | grep -qiE "(^|[;&|([:space:]]+)canvas[[:space:]]+${pat}([[:space:]]|\$)"; then
+    # Trailing boundary accepts separators too: "canvas favorites courses
+    # reset;true" glues ";" to the verb and must still match.
+    if printf '%s' "$cleaned" | grep -qiE "(^|[;&|([:space:]]+)([^[:space:]]*/)?canvas[[:space:]]+${pat}([[:space:];&|)]|\$)"; then
       return 0
     fi
   done
@@ -224,7 +229,7 @@ bash_is_blocked() {
 # a GET whose PATH contains "delete" or "posts" is NOT blocked.
 api_is_blocked() {
   local cleaned="$1"
-  printf '%s' "$cleaned" | grep -qiE "(^|[;&|([:space:]]+)canvas[[:space:]]+api[[:space:]]+(DELETE|PUT|POST|PATCH)[[:space:]/]"
+  printf '%s' "$cleaned" | grep -qiE "(^|[;&|([:space:]]+)([^[:space:]]*/)?canvas[[:space:]]+api[[:space:]]+(DELETE|PUT|POST|PATCH)[[:space:]/]"
 }
 
 # Without jq we cannot isolate the tool_name/command fields. Fail safe: apply
@@ -232,7 +237,11 @@ api_is_blocked() {
 # than a loose canvas.*verb scan that would flag any Bash line mentioning
 # canvas+verb (e.g. "cat courses_delete.go").
 if ! command -v jq >/dev/null 2>&1; then
-  flat=$(printf '%s' "$input" | tr '\n' ' ')
+  # Flatten JSON punctuation to spaces BEFORE matching: in the raw compact
+  # payload the command value is glued to its key ("command":"canvas ...),
+  # and without this the anchored pattern can never match — the branch would
+  # silently fail OPEN, not safe.
+  flat=$(printf '%s' "$input" | tr '\n{}:,' '     ')
   cleaned=$(deobfuscate "$flat")
   if bash_is_blocked "$cleaned"; then
     deny_raw "canvas agent guard: irreversible operation blocked (jq unavailable; raw match)."

--- a/commands/agent_test.go
+++ b/commands/agent_test.go
@@ -265,6 +265,23 @@ func TestClassifyCanvasCommands_BulkDestructivePaths(t *testing.T) {
 	assertContainsPath(t, "read", read, "sis-imports list")
 }
 
+// TestClassifyCanvasCommands_WriteOverridePaths verifies that paths whose leaf
+// name collides with a read verb but actually write (e.g. "sync assignments",
+// which shares its leaf with the "analytics assignments" read) are forced into
+// the write bucket by canvasWriteOverridePaths.
+func TestClassifyCanvasCommands_WriteOverridePaths(t *testing.T) {
+	read, writes, _ := classifyCanvasCommands(rootCmd)
+
+	// "sync assignments" copies assignments INTO a target course — must ask.
+	assertContainsPath(t, "write (override)", writes, "sync assignments")
+	assertNotContainsPath(t, "read (must not)", read, "sync assignments")
+
+	// The genuine read that shares the leaf name is unaffected.
+	assertContainsPath(t, "read", read, "analytics assignments")
+	// The sibling sync command stays a write via the fail-safe default.
+	assertContainsPath(t, "write", writes, "sync course")
+}
+
 // --- guardPlan ---
 
 func TestGuardPlan_BlockedAndAsked(t *testing.T) {

--- a/docs/user-guide/agent-safety.md
+++ b/docs/user-guide/agent-safety.md
@@ -58,7 +58,7 @@ However, these patterns are best-effort. Variable indirection (`M=DELETE; canvas
 
 ## Obfuscation caveats
 
-The Bash hook defeats trivial quote/backslash obfuscation (`canvas courses de""lete 1`, `canvas courses delete\ 1`) by stripping those characters before pattern matching. It does **not** defeat:
+The Bash hook defeats trivial quote/backslash obfuscation (`canvas courses de""lete 1`, `canvas courses delete\ 1`) by stripping those characters before pattern matching, and matches path-invoked binaries (`./bin/canvas courses delete 1`, `/usr/local/bin/canvas courses delete 1`) as well as the bare `canvas` name. It does **not** defeat:
 
 - **Variable indirection**: `v=delete; canvas courses $v 1`
 - **Shell aliases**: `alias rm='canvas courses delete'`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -841,7 +841,7 @@ func (c *Client) GetAllPages(ctx context.Context, path string, result interface{
 	// Use reflection to directly append results to the slice
 	// This avoids unnecessary marshal/unmarshal round-trip
 	resultValue := reflect.ValueOf(result)
-	if resultValue.Kind() != reflect.Ptr || resultValue.Elem().Kind() != reflect.Slice {
+	if resultValue.Kind() != reflect.Pointer || resultValue.Elem().Kind() != reflect.Slice {
 		return fmt.Errorf("result must be a pointer to a slice")
 	}
 

--- a/internal/api/params.go
+++ b/internal/api/params.go
@@ -45,7 +45,7 @@ func (b *ParamsBuilder) Set(key string, value interface{}) *ParamsBuilder {
 
 	// Dereference pointer if needed
 	v := reflect.ValueOf(value)
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
 		value = v.Elem().Interface()
 	}
 
@@ -64,7 +64,7 @@ func (b *ParamsBuilder) SetBool(key string, value interface{}) *ParamsBuilder {
 	v := reflect.ValueOf(value)
 
 	// Handle pointer to bool
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return b
 		}
@@ -126,7 +126,7 @@ func (b *ParamsBuilder) isZeroValue(value interface{}) bool {
 	v := reflect.ValueOf(value)
 
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return v.IsNil()
 	case reflect.String:
 		return v.String() == ""

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -271,7 +271,7 @@ func (f *TableFormatter) Format(data interface{}) (string, error) {
 // filterKeyFields filters headers to only include key fields for the given item type
 func (f *TableFormatter) filterKeyFields(item interface{}, allHeaders []string) []string {
 	v := reflect.ValueOf(item)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -337,7 +337,7 @@ func getHeaders(item interface{}) []string {
 	v := reflect.ValueOf(item)
 
 	// Handle pointers
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -377,7 +377,7 @@ func getRow(item interface{}, headers []string) []string {
 	v := reflect.ValueOf(item)
 
 	// Handle pointers
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 
@@ -458,7 +458,7 @@ func formatValue(v interface{}) string {
 	val := reflect.ValueOf(v)
 
 	// Handle nil pointers
-	if val.Kind() == reflect.Ptr && val.IsNil() {
+	if val.Kind() == reflect.Pointer && val.IsNil() {
 		return ""
 	}
 
@@ -501,7 +501,7 @@ func formatValue(v interface{}) string {
 	case reflect.Struct:
 		// For structs, try to find a name/title/id field to display
 		return formatStructCompact(val)
-	case reflect.Ptr:
+	case reflect.Pointer:
 		// Handle pointers to structs
 		if !val.IsNil() && val.Elem().Kind() == reflect.Struct {
 			return formatStructCompact(val.Elem())

--- a/tools/speccheck/main.go
+++ b/tools/speccheck/main.go
@@ -492,13 +492,13 @@ func runCoverage() error {
 
 	var sb strings.Builder
 	sb.WriteString("# Canvas CLI Official Spec Coverage Gap Report\n\n")
-	sb.WriteString(fmt.Sprintf("**%s**\n\n", summary))
+	fmt.Fprintf(&sb, "**%s**\n\n", summary)
 	sb.WriteString("Source: official Canvas Swagger 1.2 (refresh with `make spec-sync`)\n\n")
 	sb.WriteString("| Resource | Implemented | Documented | Gap |\n")
 	sb.WriteString("|----------|------------|------------|-----|\n")
 	for _, r := range resources {
 		rg := byResource[r]
-		sb.WriteString(fmt.Sprintf("| %s | %d | %d | %d |\n", r, rg.implemented, rg.total, len(rg.missing)))
+		fmt.Fprintf(&sb, "| %s | %d | %d | %d |\n", r, rg.implemented, rg.total, len(rg.missing))
 	}
 	sb.WriteString("\n## Missing Endpoints (official Canvas spec but not implemented by CLI)\n\n")
 	for _, r := range resources {
@@ -506,9 +506,9 @@ func runCoverage() error {
 		if len(rg.missing) == 0 {
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("### %s\n\n", r))
+		fmt.Fprintf(&sb, "### %s\n\n", r)
 		for _, m := range rg.missing {
-			sb.WriteString(fmt.Sprintf("- `%s`\n", m))
+			fmt.Fprintf(&sb, "- `%s`\n", m)
 		}
 		sb.WriteString("\n")
 	}


### PR DESCRIPTION
## What

Hardens the generated `agent guard` PreToolUse hook against three bypasses found while reviewing the feature, plus a small pre-existing lint cleanup (separate commit).

### Guard fixes (`86c764f`)
- **Path-prefix bypass**: `./bin/canvas courses delete` and `/usr/local/bin/canvas courses delete` were not matched. Added an optional `([^[:space:]]*/)?` prefix to the bash and raw-api regexes. A different binary ending in `canvas` (`mycanvas`) still is not matched.
- **Glued-separator bypass**: `canvas favorites courses reset;true` slipped the trailing boundary (separator glued to a no-arg irreversible verb). Widened the boundary to `([[:space:];&|)]|$)`.
- **No-jq fail-open**: with `jq` absent, the anchored pattern ran against the raw compact JSON where `"command":"canvas ...` glues the command to its key, so it could never match. Now flattens JSON punctuation to spaces first. The old no-jq test never actually hid `jq` from `PATH`, masking this — now uses a strict `PATH`.
- **Classification**: `sync assignments` (leaf collides with the `analytics assignments` read verb) is now forced into the write bucket via a write-override map.

### Pre-existing lint cleanup (`04c3dde`, separable)
Unrelated to the guard; already failing lint on `develop` under the current golangci-lint. Mechanical, behavior-preserving: `reflect.Ptr`→`reflect.Pointer`, and `WriteString(fmt.Sprintf)`→`fmt.Fprintf` in speccheck.

## Testing
- Extended `commands/agent_hook_test.go` execution battery: path-prefixed invocation denied, glued separator/pipe denied, different-binary allowed, strict no-jq denied.
- `make lint` clean, `go vet` clean, `go test -race ./...` green, coverage 81.2% (≥80% gate).

## Accepted limitations (unchanged, documented)
Variable indirection, shell aliases, and `eval` remain out of scope for the Bash hook — MCP-only mode is the hard guarantee. Quoted blocked commands inside an argument (`rg "canvas courses delete" src/`) are denied conservatively because quote-stripping is the obfuscation defense.