### PR TITLE
test(telemetry): fix racy TrackError_NilProperties assertion

### DIFF
--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -587,21 +587,25 @@ func TestClient_TrackError_NilProperties(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
-	defer client.Close()
-
-	// Track error with nil properties
+	// Track error with nil properties.
 	client.TrackError("validation_error", "Invalid input", nil)
 
-	client.mu.Lock()
-	defer client.mu.Unlock()
-
-	if len(client.events) != 1 {
-		t.Errorf("expected 1 event, got %d", len(client.events))
+	// TrackError signals the flush worker, which may drain client.events to
+	// disk at any moment — asserting on the in-memory slice is racy. Close()
+	// performs the final flush, so the event is guaranteed to be on disk after
+	// it returns; assert on the flushed files instead.
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
 	}
 
-	event := client.events[0]
+	events := readFlushedEvents(t, tempDir)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 flushed event, got %d", len(events))
+	}
+
+	event := events[0]
 	if event.Properties == nil {
-		t.Error("expected properties to be initialized")
+		t.Fatal("expected properties to be initialized")
 	}
 
 	if event.Properties["error_type"] != "validation_error" {


### PR DESCRIPTION
## What

`TestClient_TrackError_NilProperties` intermittently failed on Windows CI (`expected 1 event, got 0`, then an index-out-of-range panic).

## Why

The test read `client.events` directly after `TrackError`, but `TrackError` signals the async flush worker (it flushes errors immediately), and `Flush()` clears `c.events`. On slower Windows runners the worker often won the race, so the slice was already empty when the test asserted — `len` was 0 and `client.events[0]` panicked.

## Fix

Assert on the flushed files after `Close()` (which performs the final flush and waits for the worker to exit) instead of the racy in-memory slice — exactly the pattern the sibling `TestClient_TrackError` already uses, via the existing `readFlushedEvents` helper. Test-only change; no production code touched.

## Testing

200 iterations under `-race` all pass; full `internal/telemetry` package green; `make lint` clean.