### PR TITLE
test: make doctor command tests deterministic (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ sync by `make docs-gen` and the documentation workflow.
 - Canvas Studio integration
 - GraphQL API support
 
+### Changed
+
+- `canvas doctor`: the command now resolves its diagnostics runner through an
+  injectable `diagnostics.Runner` seam (`newDoctorRunner`) instead of calling
+  `diagnostics.New` directly. Runtime behavior is unchanged for users; the seam
+  lets the command tests drive deterministic fake reports so
+  `go test ./commands -run TestDoctorCmd` no longer depends on live network,
+  host permissions, or real credentials — and no longer skips under CI. The
+  real end-to-end path remains covered by an opt-in smoke test gated behind
+  `CANVAS_DOCTOR_LIVE=1`. ([#28](https://github.com/jjuanrivvera/canvas-cli/issues/28))
+
 ## [1.11.0] - 2026-07-13
 
 ### Added

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,43 @@
+# Decisions
+
+Numbered record of ambiguous design/API assumptions and non-obvious engineering
+choices for canvas-cli. Each entry captures the decision, the alternatives, and
+the rationale so the reasoning survives beyond the diff.
+
+## 1. Diagnostics runner injection seam for deterministic `canvas doctor` tests
+
+**Context.** `canvas doctor` runs environment, configuration, connectivity,
+authentication, API-access, disk-space, and permission checks. Several of these
+touch live network, the host filesystem, and real credentials, so the command
+tests (`TestDoctorCmd`) were flaky in local runs and were skipped entirely under
+`CI=1` / `GITHUB_ACTIONS` — a crutch that traded determinism for coverage.
+
+**Decision.** Introduce a `diagnostics.Runner` interface
+(`Run(ctx) (*Report, error)`, already satisfied by `*diagnostics.Doctor`) and
+route the command through an injectable package var
+`newDoctorRunner(cfg, client) diagnostics.Runner` in `commands/doctor.go`
+instead of calling `diagnostics.New` directly. The production default is
+unchanged. Command tests override the seam with a `fakeRunner` that returns a
+deterministic `*diagnostics.Report`, exercising every output format (human,
+human-verbose, `--json`, and global `-o json`) plus failure and runner-error
+handling — with no network, host-permission, or real-credential dependency.
+
+**Alternatives considered.**
+- *Inject each check's dependency (HTTP client, filesystem) into `Doctor`.*
+  Rejected as heavier than needed: the diagnostics package tests
+  (`internal/diagnostics`, ~97% covered) already drive individual checks against
+  `httptest` and temp dirs deterministically. The flakiness lived at the
+  *command* layer, so the seam belongs there.
+- *Keep the `CI=1` skip.* Rejected — it leaves the command untested in CI and
+  still flaky locally, which is exactly the bug (#28).
+
+**Consequences.**
+- `go test ./commands -run TestDoctorCmd` is deterministic and host-free by
+  default (≈0.02s vs ≈6s), and no longer skips under CI.
+- The real end-to-end path stays covered by a single opt-in smoke test,
+  `TestDoctorCmd_Live`, gated behind `CANVAS_DOCTOR_LIVE=1` and skipped by
+  default.
+- Runtime behavior of `canvas doctor` for real users is unchanged; this is a
+  testability refactor only.
+
+Ref: [#28](https://github.com/jjuanrivvera/canvas-cli/issues/28)

--- a/commands/doctor.go
+++ b/commands/doctor.go
@@ -11,8 +11,19 @@ import (
 
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/logging"
 	"github.com/jjuanrivvera/canvas-cli/commands/internal/options"
+	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
 	"github.com/jjuanrivvera/canvas-cli/internal/diagnostics"
 )
+
+// newDoctorRunner builds the diagnostics runner used by `canvas doctor`. It is a
+// package var (not a direct call to diagnostics.New) so tests can inject a
+// deterministic fake runner in place of the production runner, whose checks
+// depend on live network, local credentials, and host filesystem state. The
+// production default is unchanged for real users.
+var newDoctorRunner = func(cfg *config.Config, client *api.Client) diagnostics.Runner {
+	return diagnostics.New(cfg, client)
+}
 
 func init() {
 	rootCmd.AddCommand(newDoctorCmd())
@@ -88,8 +99,8 @@ func runDoctor(ctx context.Context, opts *options.DoctorOptions) error {
 		client = nil
 	}
 
-	// Create doctor instance
-	doctor := diagnostics.New(cfg, client)
+	// Create doctor instance (injectable seam; see newDoctorRunner)
+	doctor := newDoctorRunner(cfg, client)
 
 	// Run diagnostics
 	if !opts.JSON {

--- a/commands/doctor_test.go
+++ b/commands/doctor_test.go
@@ -1,89 +1,253 @@
 package commands
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	cmdtest "github.com/jjuanrivvera/canvas-cli/commands/internal/testing"
+	"github.com/jjuanrivvera/canvas-cli/internal/api"
+	"github.com/jjuanrivvera/canvas-cli/internal/config"
+	"github.com/jjuanrivvera/canvas-cli/internal/diagnostics"
 )
 
-func TestDoctorCmd(t *testing.T) {
-	// Skip in CI as doctor performs real system diagnostics that may fail in CI environments
-	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
-		t.Skip("Skipping doctor tests in CI environment")
-	}
+// fakeRunner is a deterministic diagnostics.Runner used to drive the doctor
+// command's output/formatting and failure-handling paths without touching the
+// network, host filesystem, or real credentials.
+type fakeRunner struct {
+	report *diagnostics.Report
+	err    error
+}
 
-	tests := []cmdtest.CommandTestCase{
-		{
-			Name: "doctor check passes",
-			Args: []string{},
-			MockResponses: map[string]cmdtest.MockResponse{
-				"/api/v1/users/self": cmdtest.NewMockResponse(`{
-					"id": 1,
-					"name": "Test User",
-					"short_name": "Test",
-					"sortable_name": "User, Test",
-					"email": "test@example.com"
-				}`),
-				"/api/v1/courses": cmdtest.NewMockResponse(`[]`),
+func (f *fakeRunner) Run(_ context.Context) (*diagnostics.Report, error) {
+	return f.report, f.err
+}
+
+// withDoctorRunner swaps the package-level newDoctorRunner seam for one that
+// returns the given runner, restoring the original when the test finishes.
+func withDoctorRunner(t *testing.T, runner diagnostics.Runner) {
+	t.Helper()
+	orig := newDoctorRunner
+	newDoctorRunner = func(_ *config.Config, _ *api.Client) diagnostics.Runner {
+		return runner
+	}
+	t.Cleanup(func() { newDoctorRunner = orig })
+}
+
+// healthyReport builds a deterministic all-green report covering every status
+// the human formatter renders (PASS/WARN/SKIP), with no failures.
+func healthyReport() *diagnostics.Report {
+	return &diagnostics.Report{
+		Checks: []diagnostics.Check{
+			{Name: "Environment", Description: "System environment and runtime", Status: diagnostics.StatusPass, Message: "OS: linux", Duration: time.Millisecond},
+			{Name: "Configuration", Description: "Configuration file and settings", Status: diagnostics.StatusPass, Message: "Instance: test", Duration: time.Millisecond},
+			{Name: "Connectivity", Description: "Network connectivity to Canvas", Status: diagnostics.StatusSkipped, Message: "Configuration not available", Duration: time.Millisecond},
+			{Name: "Permissions", Description: "File and directory permissions", Status: diagnostics.StatusWarning, Message: "insecure permissions", Duration: time.Millisecond},
+		},
+		Duration:  5 * time.Millisecond,
+		PassCount: 2,
+		WarnCount: 1,
+		SkipCount: 1,
+	}
+}
+
+// unhealthyReport builds a deterministic report with a failing check.
+func unhealthyReport() *diagnostics.Report {
+	return &diagnostics.Report{
+		Checks: []diagnostics.Check{
+			{Name: "Environment", Description: "System environment and runtime", Status: diagnostics.StatusPass, Message: "OS: linux", Duration: time.Millisecond},
+			{
+				Name:        "Authentication",
+				Description: "API token authentication",
+				Status:      diagnostics.StatusFail,
+				Message:     "Authentication failed: invalid token",
+				Error:       context.DeadlineExceeded,
+				Duration:    time.Millisecond,
 			},
-			ExpectError: false,
-			ValidateOutput: func(t *testing.T, output string) {
-				if !strings.Contains(output, "Running diagnostics") {
-					t.Error("Expected 'Running diagnostics' in output")
-				}
-				if !strings.Contains(output, "Environment") {
-					t.Error("Expected 'Environment' check in output")
+		},
+		Duration:  3 * time.Millisecond,
+		PassCount: 1,
+		FailCount: 1,
+	}
+}
+
+func TestDoctorCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		runner      diagnostics.Runner
+		expectError bool
+		validate    func(t *testing.T, output string)
+	}{
+		{
+			name:   "human output, healthy",
+			args:   []string{},
+			runner: &fakeRunner{report: healthyReport()},
+			validate: func(t *testing.T, output string) {
+				assertContains(t, output, "Running diagnostics")
+				assertContains(t, output, "Diagnostic Report")
+				assertContains(t, output, "Environment")
+				assertContains(t, output, "Permissions")
+				assertContains(t, output, "All checks passed")
+				// Non-verbose must not print per-check descriptions.
+				if strings.Contains(output, "Description:") {
+					t.Errorf("non-verbose output should not contain per-check Description, got:\n%s", output)
 				}
 			},
 		},
 		{
-			Name: "doctor check with verbose",
-			Args: []string{"--verbose"},
-			MockResponses: map[string]cmdtest.MockResponse{
-				"/api/v1/users/self": cmdtest.NewMockResponse(`{
-					"id": 1,
-					"name": "Test User",
-					"short_name": "Test",
-					"sortable_name": "User, Test",
-					"email": "test@example.com"
-				}`),
-				"/api/v1/courses": cmdtest.NewMockResponse(`[]`),
+			name:   "human output, verbose",
+			args:   []string{"--verbose"},
+			runner: &fakeRunner{report: healthyReport()},
+			validate: func(t *testing.T, output string) {
+				assertContains(t, output, "Description: System environment and runtime")
+				assertContains(t, output, "Duration:")
 			},
-			ExpectError: false,
-			ValidateOutput: func(t *testing.T, output string) {
-				if !strings.Contains(output, "Description") {
-					t.Error("Expected 'Description' in verbose output")
+		},
+		{
+			name:        "human output, failing check",
+			args:        []string{},
+			runner:      &fakeRunner{report: unhealthyReport()},
+			expectError: true,
+			validate: func(t *testing.T, output string) {
+				assertContains(t, output, "Authentication")
+				assertContains(t, output, "check(s) failed")
+				assertContains(t, output, "1 check(s) failed")
+			},
+		},
+		{
+			name:        "verbose failing check shows error line",
+			args:        []string{"--verbose"},
+			runner:      &fakeRunner{report: unhealthyReport()},
+			expectError: true,
+			validate: func(t *testing.T, output string) {
+				assertContains(t, output, "Error:")
+			},
+		},
+		{
+			name:   "json output via --json flag",
+			args:   []string{"--json"},
+			runner: &fakeRunner{report: healthyReport()},
+			validate: func(t *testing.T, output string) {
+				var r struct {
+					Duration string `json:"duration"`
+					Summary  string `json:"summary"`
+					Healthy  bool   `json:"healthy"`
+					Checks   []struct {
+						Name   string `json:"name"`
+						Status string `json:"status"`
+					} `json:"checks"`
+				}
+				// The deprecated --json flag makes cobra append a deprecation
+				// notice after the JSON; a streaming decoder reads just the
+				// first value and ignores the trailing text.
+				if err := json.NewDecoder(strings.NewReader(output)).Decode(&r); err != nil {
+					t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, output)
+				}
+				if !r.Healthy {
+					t.Errorf("expected healthy=true, got false")
+				}
+				if len(r.Checks) != 4 {
+					t.Errorf("expected 4 checks in JSON, got %d", len(r.Checks))
+				}
+				// JSON path must not emit the human "Running diagnostics" banner.
+				if strings.Contains(output, "Running diagnostics") {
+					t.Errorf("JSON output should not contain human banner")
 				}
 			},
 		},
 		{
-			Name: "doctor check with JSON output",
-			Args: []string{"--json"},
-			MockResponses: map[string]cmdtest.MockResponse{
-				"/api/v1/users/self": cmdtest.NewMockResponse(`{
-					"id": 1,
-					"name": "Test User"
-				}`),
-				"/api/v1/courses": cmdtest.NewMockResponse(`[]`),
-			},
-			ExpectError: false,
-			ValidateOutput: func(t *testing.T, output string) {
-				if !strings.Contains(output, `"duration"`) {
-					t.Error("Expected JSON output with duration field")
+			name:        "json output, failing check reports healthy=false",
+			args:        []string{"--json"},
+			runner:      &fakeRunner{report: unhealthyReport()},
+			expectError: true,
+			validate: func(t *testing.T, output string) {
+				var r struct {
+					Healthy bool `json:"healthy"`
 				}
-				if !strings.Contains(output, `"healthy"`) {
-					t.Error("Expected JSON output with healthy field")
+				if err := json.NewDecoder(strings.NewReader(output)).Decode(&r); err != nil {
+					t.Fatalf("output is not valid JSON: %v", err)
+				}
+				if r.Healthy {
+					t.Errorf("expected healthy=false for failing report")
 				}
 			},
+		},
+		{
+			name:        "runner error surfaces as diagnostic error",
+			args:        []string{},
+			runner:      &fakeRunner{err: context.DeadlineExceeded},
+			expectError: true,
+			validate:    func(t *testing.T, _ string) {},
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.Name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
+			withDoctorRunner(t, tc.runner)
 			cmd := newDoctorCmd()
-			cmdtest.RunCommandTest(t, cmd, tc)
+			cmdtest.RunCommandTest(t, cmd, cmdtest.CommandTestCase{
+				Name:           tc.name,
+				Args:           tc.args,
+				ExpectError:    tc.expectError,
+				ValidateOutput: tc.validate,
+			})
 		})
+	}
+}
+
+// TestDoctorCmd_OutputJSONViaGlobalFlag covers the -o/--output json code path,
+// which maps the global outputFormat onto opts.JSON.
+func TestDoctorCmd_OutputJSONViaGlobalFlag(t *testing.T) {
+	withDoctorRunner(t, &fakeRunner{report: healthyReport()})
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := newDoctorCmd()
+	cmdtest.RunCommandTest(t, cmd, cmdtest.CommandTestCase{
+		Name: "global -o json",
+		Args: []string{},
+		ValidateOutput: func(t *testing.T, output string) {
+			assertContains(t, output, `"healthy"`)
+			if strings.Contains(output, "Running diagnostics") {
+				t.Errorf("global -o json should suppress the human banner")
+			}
+		},
+	})
+}
+
+// TestDoctorCmd_Live is the single opt-in end-to-end smoke test that exercises
+// the real diagnostics runner (real environment/network/filesystem checks). It
+// is skipped by default and only runs when CANVAS_DOCTOR_LIVE=1, so the default
+// `go test ./commands -run TestDoctorCmd` stays deterministic and host-free.
+func TestDoctorCmd_Live(t *testing.T) {
+	if os.Getenv("CANVAS_DOCTOR_LIVE") != "1" {
+		t.Skip("set CANVAS_DOCTOR_LIVE=1 to run the live doctor smoke test")
+	}
+
+	cmd := newDoctorCmd()
+	cmdtest.RunCommandTest(t, cmd, cmdtest.CommandTestCase{
+		Name: "live doctor",
+		Args: []string{},
+		MockResponses: map[string]cmdtest.MockResponse{
+			"/api/v1/users/self": cmdtest.NewMockResponse(`{"id":1,"name":"Test User"}`),
+			"/api/v1/courses":    cmdtest.NewMockResponse(`[]`),
+		},
+		ValidateOutput: func(t *testing.T, output string) {
+			assertContains(t, output, "Diagnostic Report")
+			assertContains(t, output, "Environment")
+		},
+	})
+}
+
+func assertContains(t *testing.T, output, want string) {
+	t.Helper()
+	if !strings.Contains(output, want) {
+		t.Errorf("expected output to contain %q, got:\n%s", want, output)
 	}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,17 @@ sync by `make docs-gen` and the documentation workflow.
 - Canvas Studio integration
 - GraphQL API support
 
+### Changed
+
+- `canvas doctor`: the command now resolves its diagnostics runner through an
+  injectable `diagnostics.Runner` seam (`newDoctorRunner`) instead of calling
+  `diagnostics.New` directly. Runtime behavior is unchanged for users; the seam
+  lets the command tests drive deterministic fake reports so
+  `go test ./commands -run TestDoctorCmd` no longer depends on live network,
+  host permissions, or real credentials — and no longer skips under CI. The
+  real end-to-end path remains covered by an opt-in smoke test gated behind
+  `CANVAS_DOCTOR_LIVE=1`. ([#28](https://github.com/jjuanrivvera/canvas-cli/issues/28))
+
 ## [1.11.0] - 2026-07-13
 
 ### Added

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -43,6 +43,14 @@ type Report struct {
 	SkipCount int
 }
 
+// Runner runs diagnostic checks and produces a Report. The concrete *Doctor
+// implements it; the interface is the seam that lets callers (notably the
+// `canvas doctor` command) inject a deterministic fake in tests instead of
+// exercising the real environment, network, and filesystem checks.
+type Runner interface {
+	Run(ctx context.Context) (*Report, error)
+}
+
 // Doctor performs system diagnostics
 type Doctor struct {
 	config *config.Config


### PR DESCRIPTION
Fixes #28

## What
Make the `canvas doctor` command tests deterministic and network/host-free by default, without changing the command's runtime behavior for users.

## Why
`TestDoctorCmd` was flaky in local runs because `canvas doctor` performs environment + network + filesystem checks that depend on host state and real credentials. The tests skipped under `CI=1`, so the command was effectively untested in CI and still flaky locally.

## How
- Add a `diagnostics.Runner` interface (already satisfied by `*diagnostics.Doctor`) and route the command through an injectable `newDoctorRunner` seam in `commands/doctor.go`. Production default unchanged.
- Rewrite `commands/doctor_test.go` to drive deterministic fake reports through the seam, covering all output formats (human, verbose, `--json`, global `-o json`) plus failure and runner-error handling — no live network, host permissions, or real credentials.
- Keep one opt-in end-to-end smoke test (`TestDoctorCmd_Live`) behind `CANVAS_DOCTOR_LIVE=1`, skipped by default.
- Remove the `CI=1` skip crutch.
- Document the seam in `DECISIONS.md` (#1) and `CHANGELOG.md`.

## Verification
- `go test ./commands -run TestDoctorCmd` is deterministic (≈0.02s, repeatable, `-race -count=3` clean).
- `make check` green; total coverage 81.1% (≥80 gate held).