### PR TITLE
fix: tolerate Canvas response-shape quirks (#55 required_permissions, #56 array-wrapped objects)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -516,6 +516,50 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 	return resp, nil
 }
 
+// unmarshalTolerant decodes body into result, tolerating Canvas endpoints that
+// occasionally return a single object wrapped in an array (e.g. some deployments
+// answer an enrollment create with [] or [obj] instead of obj). When the body is
+// a JSON array and result targets a single (non-slice) value, the first element
+// is used; an empty array leaves result zero-valued and is treated as success.
+// Any other decode error is returned unchanged, and slice targets keep normal
+// semantics.
+func unmarshalTolerant(body []byte, result interface{}) error {
+	err := json.Unmarshal(body, result)
+	if err == nil {
+		return nil
+	}
+
+	// Only attempt the array fallback when the body actually is a JSON array.
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return err
+	}
+
+	rv := reflect.ValueOf(result)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return err
+	}
+	elemType := rv.Elem().Type()
+	if elemType.Kind() == reflect.Slice {
+		// Target already expects a slice; the original error stands.
+		return err
+	}
+
+	slicePtr := reflect.New(reflect.SliceOf(elemType))
+	if e := json.Unmarshal(body, slicePtr.Interface()); e != nil {
+		// Not an array of the target type — surface the original error.
+		return err
+	}
+	slice := slicePtr.Elem()
+	if slice.Len() > 0 {
+		rv.Elem().Set(slice.Index(0))
+	} else {
+		// Empty array: reset result to its zero value and treat as success.
+		rv.Elem().Set(reflect.Zero(elemType))
+	}
+	return nil
+}
+
 // DeleteJSON performs a DELETE request and decodes the JSON response body into
 // result. If result is nil the body is discarded. This is the preferred method
 // when the Canvas DELETE endpoint returns a meaningful JSON body.
@@ -532,7 +576,7 @@ func (c *Client) DeleteJSON(ctx context.Context, path string, result interface{}
 	}
 
 	if result != nil {
-		return json.Unmarshal(bodyBytes, result)
+		return unmarshalTolerant(bodyBytes, result)
 	}
 	return nil
 }
@@ -566,7 +610,7 @@ func (c *Client) GetJSON(ctx context.Context, path string, result interface{}) e
 	}
 
 	// Decode the response
-	if err := json.Unmarshal(body, result); err != nil {
+	if err := unmarshalTolerant(body, result); err != nil {
 		return err
 	}
 
@@ -602,7 +646,7 @@ func (c *Client) PostJSON(ctx context.Context, path string, body interface{}, re
 	}
 
 	if result != nil {
-		return json.Unmarshal(bodyBytes, result)
+		return unmarshalTolerant(bodyBytes, result)
 	}
 
 	return nil
@@ -631,7 +675,7 @@ func (c *Client) PutJSON(ctx context.Context, path string, body interface{}, res
 	}
 
 	if result != nil {
-		return json.Unmarshal(bodyBytes, result)
+		return unmarshalTolerant(bodyBytes, result)
 	}
 
 	return nil
@@ -661,7 +705,7 @@ func (c *Client) PatchJSON(ctx context.Context, path string, body interface{}, r
 	}
 
 	if result != nil {
-		return json.Unmarshal(bodyBytes, result)
+		return unmarshalTolerant(bodyBytes, result)
 	}
 
 	return nil

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -848,11 +848,15 @@ func (c *Client) GetAllPages(ctx context.Context, path string, result interface{
 	sliceValue := resultValue.Elem()
 	elemType := sliceValue.Type().Elem()
 
-	for _, raw := range allResults {
+	for i, raw := range allResults {
 		// Create a new element of the slice's element type
 		elem := reflect.New(elemType)
 		if err := json.Unmarshal(raw, elem.Interface()); err != nil {
-			return fmt.Errorf("failed to unmarshal element: %w", err)
+			// Degrade gracefully: one malformed element shouldn't discard the
+			// whole page. Warn and skip it so the command stays useful.
+			c.logger.Warn("skipping list element that failed to decode",
+				"index", i, "error", err)
+			continue
 		}
 		sliceValue = reflect.Append(sliceValue, elem.Elem())
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1107,3 +1107,65 @@ func BenchmarkGetAllPages_LargeDataset_Generics(b *testing.B) {
 		}
 	}
 }
+
+func TestUnmarshalTolerant(t *testing.T) {
+	type item struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	}
+
+	t.Run("single object", func(t *testing.T) {
+		var got item
+		if err := unmarshalTolerant([]byte(`{"id":1,"name":"a"}`), &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ID != 1 || got.Name != "a" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("array uses first element", func(t *testing.T) {
+		var got item
+		if err := unmarshalTolerant([]byte(`[{"id":2,"name":"b"},{"id":3,"name":"c"}]`), &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ID != 2 || got.Name != "b" {
+			t.Errorf("expected first element, got %+v", got)
+		}
+	})
+
+	t.Run("empty array is success and leaves zero value", func(t *testing.T) {
+		got := item{ID: 99, Name: "pre"}
+		if err := unmarshalTolerant([]byte(`[]`), &got); err != nil {
+			t.Fatalf("empty array should not error: %v", err)
+		}
+		if got.ID != 0 || got.Name != "" {
+			t.Errorf("expected zero value, got %+v", got)
+		}
+	})
+
+	t.Run("slice target keeps normal semantics", func(t *testing.T) {
+		var got []item
+		if err := unmarshalTolerant([]byte(`[{"id":4,"name":"d"}]`), &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != 4 {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("non-array decode error is returned", func(t *testing.T) {
+		var got item
+		if err := unmarshalTolerant([]byte(`"a string"`), &got); err == nil {
+			t.Errorf("expected error decoding a string into a struct, got nil")
+		}
+	})
+
+	t.Run("array of wrong type surfaces original error", func(t *testing.T) {
+		var got item
+		// Array whose elements can't decode into item -> original error stands.
+		if err := unmarshalTolerant([]byte(`["x","y"]`), &got); err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+}

--- a/internal/api/enrollments_test.go
+++ b/internal/api/enrollments_test.go
@@ -733,3 +733,50 @@ func TestEnrollmentsService_EnrollUser_WithAllOptions(t *testing.T) {
 		t.Errorf("Expected enrollment ID 999, got %d", enrollment.ID)
 	}
 }
+
+// Regression for #56: some Canvas deployments answer an enrollment create with
+// an array (a single-element array, or an empty [] on success) instead of a
+// single object. EnrollUser must handle both without reporting a false failure.
+func TestEnrollmentsService_EnrollUser_ArrayResponse(t *testing.T) {
+	t.Run("single-element array", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v1/accounts" {
+				handleVersionDetection(w)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"id":42,"user_id":789,"course_id":123,"type":"StudentEnrollment","enrollment_state":"active"}]`))
+		}))
+		defer server.Close()
+
+		service := NewEnrollmentsService(newTestClient(t, server.URL))
+		enr, err := service.EnrollUser(context.Background(), 123, &EnrollUserParams{UserID: 789, Type: "StudentEnrollment", EnrollmentState: "active"})
+		if err != nil {
+			t.Fatalf("EnrollUser should handle an array response: %v", err)
+		}
+		if enr == nil || enr.ID != 42 {
+			t.Fatalf("expected enrollment id 42, got %+v", enr)
+		}
+	})
+
+	t.Run("empty array is success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v1/accounts" {
+				handleVersionDetection(w)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+		}))
+		defer server.Close()
+
+		service := NewEnrollmentsService(newTestClient(t, server.URL))
+		enr, err := service.EnrollUser(context.Background(), 123, &EnrollUserParams{UserID: 789, Type: "StudentEnrollment", EnrollmentState: "active"})
+		if err != nil {
+			t.Fatalf("EnrollUser must not fail on an empty-array success response: %v", err)
+		}
+		if enr == nil {
+			t.Fatalf("expected a non-nil enrollment on success")
+		}
+	})
+}

--- a/internal/api/external_tools.go
+++ b/internal/api/external_tools.go
@@ -2,10 +2,44 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 )
+
+// CommaSeparatedList decodes a Canvas field that may arrive either as a JSON
+// array of strings or as a single comma-separated string. Canvas is inconsistent
+// here — e.g. a placement's required_permissions comes back as "a,b,c" on some
+// account-level tools but as ["a","b","c"] elsewhere — and modelling it as a plain
+// []string makes the whole list decode fail. It always round-trips as an array.
+type CommaSeparatedList []string
+
+// UnmarshalJSON accepts both the array and comma-separated-string shapes.
+func (c *CommaSeparatedList) UnmarshalJSON(b []byte) error {
+	// Preferred (documented) shape: a JSON array of strings.
+	var arr []string
+	if err := json.Unmarshal(b, &arr); err == nil {
+		*c = arr
+		return nil
+	}
+	// Fallback: a single comma-separated string.
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if strings.TrimSpace(s) == "" {
+		*c = nil
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	*c = parts
+	return nil
+}
 
 // ExternalToolsService handles external tool-related API calls
 type ExternalToolsService struct {
@@ -56,23 +90,23 @@ type ExternalTool struct {
 
 // ToolPlacement represents a tool placement configuration
 type ToolPlacement struct {
-	Enabled             bool              `json:"enabled,omitempty"`
-	URL                 string            `json:"url,omitempty"`
-	MessageType         string            `json:"message_type,omitempty"`
-	Text                string            `json:"text,omitempty"`
-	IconURL             string            `json:"icon_url,omitempty"`
-	SelectionWidth      int               `json:"selection_width,omitempty"`
-	SelectionHeight     int               `json:"selection_height,omitempty"`
-	Labels              map[string]string `json:"labels,omitempty"`
-	Visibility          string            `json:"visibility,omitempty"`
-	DisplayType         string            `json:"display_type,omitempty"`
-	LaunchWidth         int               `json:"launch_width,omitempty"`
-	LaunchHeight        int               `json:"launch_height,omitempty"`
-	WindowTarget        string            `json:"windowTarget,omitempty"`
-	Default             string            `json:"default,omitempty"`
-	AcceptMediaTypes    string            `json:"accept_media_types,omitempty"`
-	CanvasIconClass     string            `json:"canvas_icon_class,omitempty"`
-	RequiredPermissions []string          `json:"required_permissions,omitempty"`
+	Enabled             bool               `json:"enabled,omitempty"`
+	URL                 string             `json:"url,omitempty"`
+	MessageType         string             `json:"message_type,omitempty"`
+	Text                string             `json:"text,omitempty"`
+	IconURL             string             `json:"icon_url,omitempty"`
+	SelectionWidth      int                `json:"selection_width,omitempty"`
+	SelectionHeight     int                `json:"selection_height,omitempty"`
+	Labels              map[string]string  `json:"labels,omitempty"`
+	Visibility          string             `json:"visibility,omitempty"`
+	DisplayType         string             `json:"display_type,omitempty"`
+	LaunchWidth         int                `json:"launch_width,omitempty"`
+	LaunchHeight        int                `json:"launch_height,omitempty"`
+	WindowTarget        string             `json:"windowTarget,omitempty"`
+	Default             string             `json:"default,omitempty"`
+	AcceptMediaTypes    string             `json:"accept_media_types,omitempty"`
+	CanvasIconClass     string             `json:"canvas_icon_class,omitempty"`
+	RequiredPermissions CommaSeparatedList `json:"required_permissions,omitempty"`
 }
 
 // SessionlessLaunchURL represents the response from sessionless launch

--- a/internal/api/external_tools_test.go
+++ b/internal/api/external_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -466,5 +467,106 @@ func TestExternalToolsService_DeleteFromAccount(t *testing.T) {
 	_, err = svc.DeleteFromAccount(context.Background(), 5, 99)
 	if err != nil {
 		t.Fatalf("DeleteFromAccount: %v", err)
+	}
+}
+
+func TestCommaSeparatedList_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want CommaSeparatedList
+	}{
+		{"array", `["a","b","c"]`, CommaSeparatedList{"a", "b", "c"}},
+		{"comma string", `"a,b,c"`, CommaSeparatedList{"a", "b", "c"}},
+		{"comma string with spaces", `"a, b ,c"`, CommaSeparatedList{"a", "b", "c"}},
+		{"single string", `"only"`, CommaSeparatedList{"only"}},
+		{"empty string", `""`, nil},
+		{"empty array", `[]`, CommaSeparatedList{}},
+		{"null", `null`, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got CommaSeparatedList
+			if err := json.Unmarshal([]byte(tt.in), &got); err != nil {
+				t.Fatalf("Unmarshal(%s): %v", tt.in, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Unmarshal(%s) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	// A non-string, non-array value is still an error.
+	var bad CommaSeparatedList
+	if err := json.Unmarshal([]byte(`123`), &bad); err == nil {
+		t.Errorf("expected error unmarshalling a number, got nil")
+	}
+}
+
+// Regression for #55: Canvas returns required_permissions on account-level
+// placements as a comma-separated string, which previously failed the whole
+// list decode. The list must now succeed and parse the field into a slice.
+func TestExternalToolsService_ListByAccount_RequiredPermissionsString(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			handleVersionDetection(w)
+			return
+		}
+		if r.URL.Path != "/api/v1/accounts/1/external_tools" {
+			t.Errorf("Expected path /api/v1/accounts/1/external_tools, got %s", r.URL.Path)
+		}
+		// required_permissions as a comma-separated STRING (the bug repro).
+		w.Write([]byte(`[
+			{"id": 1, "name": "Plain Tool", "url": "https://a.example.com"},
+			{"id": 2, "name": "Perm Tool", "account_navigation": {"enabled": true, "required_permissions": "manage_courses,manage_account_settings"}}
+		]`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	service := NewExternalToolsService(client)
+
+	tools, err := service.ListByAccount(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("ListByAccount failed (regression #55): %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("Expected 2 tools, got %d", len(tools))
+	}
+	got := tools[1].AccountNavigation.RequiredPermissions
+	want := CommaSeparatedList{"manage_courses", "manage_account_settings"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("RequiredPermissions = %#v, want %#v", got, want)
+	}
+}
+
+// A single malformed element must not sink the whole page: it is skipped
+// (with a warning) and the well-formed elements still come back (#55 bonus).
+func TestExternalToolsService_ListByAccount_SkipsMalformedElement(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/accounts" {
+			handleVersionDetection(w)
+			return
+		}
+		// The second element has a non-numeric id, which cannot decode into int64.
+		w.Write([]byte(`[
+			{"id": 1, "name": "Good Tool"},
+			{"id": "not-a-number", "name": "Broken Tool"}
+		]`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	service := NewExternalToolsService(client)
+
+	tools, err := service.ListByAccount(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("ListByAccount should not fail on one bad element: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("Expected 1 surviving tool, got %d", len(tools))
+	}
+	if tools[0].Name != "Good Tool" {
+		t.Errorf("Expected the well-formed tool, got %q", tools[0].Name)
 	}
 }


### PR DESCRIPTION
Two related fixes for Canvas returning loosely-typed / inconsistently-shaped responses.

### #55 — external-tools list crashes on account-level tools
Canvas returns a placement's `required_permissions` as a comma-separated **string** on some account-level tools instead of `[]string`, which failed the whole `external-tools list` decode. Adds a `CommaSeparatedList` type whose `UnmarshalJSON` accepts both shapes (string→split+trim, array→as-is) and always round-trips as an array. Also hardens `GetAllPages` so one malformed element is logged and skipped instead of discarding the whole page.

### #56 — enrollments create fails when Canvas returns an array
Some deployments answer a create/update with the object wrapped in an array (`[]` or `[obj]` instead of `obj`), so `enrollments create` reported failure even though the enrollment was created. Rather than patch one method, this fixes the **shared decode path**: `unmarshalTolerant` falls back — when the body is a JSON array and the target is a single value — to decoding into a slice and taking the first element; an empty array resets the target to zero and is treated as success. Wired into `GetJSON`/`PostJSON`/`PutJSON`/`PatchJSON`/`DeleteJSON`, so all ~26 resources that decode a single object from a mutation are now resilient, not just enrollments. Slice targets and genuine decode errors keep their existing behavior.

### Tests & gate
- Unit tables for `CommaSeparatedList` and `unmarshalTolerant` (object/array/empty/slice/error shapes), `EnrollUser` regressions (single-element + empty array), external-tools account-list regression with the string form, and a skip-malformed test.
- Full gate green locally: tests pass, coverage 81.2% (≥80), golangci-lint 0 issues, gosec clean, govulncheck clean.

Closes #55, closes #56.