### PR TITLE
mcp: emit tool annotations so read-only clients keep the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ sync by `make docs-gen` and the documentation workflow.
 
 ## [Unreleased]
 
+### Added
+
+- MCP tools now emit per-tool annotations (`readOnlyHint`, `destructiveHint`,
+  `openWorldHint`). Clients that enforce a read-only session allow a tool only
+  when `readOnlyHint` is strictly `true` and treat a missing annotation as a
+  write, so previously every tool was filtered out and the whole server was
+  dropped. 247 of 533 tools are now marked read-only. ([#58](https://github.com/jjuanrivvera/canvas-cli/issues/58))
+
+  The hints are derived from the same classification `canvas agent guard` uses,
+  so a tool cannot advertise itself as read-only while the guard gates it as a
+  write. `canvas api` and local commands that mutate state (`auth login`,
+  `config account`, `cache clear`, …) are deliberately left unannotated and are
+  therefore dropped by read-only clients.
+
 ### Planned
 
 - Canvas Studio integration

--- a/commands/agent.go
+++ b/commands/agent.go
@@ -257,68 +257,107 @@ func topLevelGroup(c *cobra.Command) string {
 	return cur.Name()
 }
 
-// classifyCanvasCommands walks the command tree and buckets every runnable
-// leaf command into read, write, or irreversible. Commands under local/utility
-// top-level groups (auth, config, cache, agent, etc.) are excluded entirely —
-// they never call the Canvas API.
+// canvasClass buckets a single command for both "canvas agent guard" and the
+// MCP tool annotations emitted by applyMCPAnnotations.
+type canvasClass int
+
+const (
+	// canvasClassSkip marks commands that are neither gated nor annotated:
+	// non-runnable parents, hidden/help commands, and the "canvas api"
+	// raw-escape hatch, which can issue any HTTP verb and so must never
+	// advertise readOnlyHint.
+	canvasClassSkip canvasClass = iota
+	// canvasClassLocal marks commands under local/utility top-level groups
+	// (auth, config, cache, …) that never call the Canvas API. The guard does
+	// not gate them; annotations handle them via canvasLocalReadPaths.
+	canvasClassLocal
+	canvasClassRead
+	canvasClassWrite
+	canvasClassIrreversible
+)
+
+// classifyCanvasCommand buckets one command. It is the single source of truth
+// shared by "canvas agent guard" and the MCP readOnlyHint annotations, so a
+// command can never be gated as a write by the guard while simultaneously
+// advertising itself as read-only to an MCP client.
 //
-// Unlike alegra-cli, canvas-cli does not set openWorldHint/readOnlyHint cobra
-// annotations, so classification is purely by verb (leaf command name).
-func classifyCanvasCommands(root *cobra.Command) (read, writes, irreversible []canvasGuardCmd) {
+// Classification is purely by verb (leaf command name) — the cobra annotations
+// flow the other way, derived from this function rather than feeding it.
+func classifyCanvasCommand(root, sub *cobra.Command) (canvasClass, canvasGuardCmd) {
+	if !sub.Runnable() || sub.Hidden || sub.Name() == "help" {
+		return canvasClassSkip, canvasGuardCmd{}
+	}
+
+	gc := canvasGuardCmd{
+		cli:  strings.TrimPrefix(sub.CommandPath(), root.Name()+" "),
+		tool: strings.ReplaceAll(sub.CommandPath(), " ", "_"),
+		verb: sub.Name(),
+	}
+
+	group := topLevelGroup(sub)
+
+	// The "api" raw-escape command is documented separately in the hook script
+	// header and cannot be safely classified by verb.
+	if group == "api" || sub.Name() == "api" {
+		return canvasClassSkip, gc
+	}
+
+	// Local/utility groups never hit the Canvas API.
+	if canvasLocalGroups[group] {
+		return canvasClassLocal, gc
+	}
+
+	// Fail-safe ordering: hard-block bulk-destructive paths and irreversible
+	// verbs, allow only explicit reads, and treat everything else — known
+	// writes AND any verb the guard doesn't recognize — as a write.
+	switch {
+	case canvasBulkDestructivePaths[gc.cli]:
+		// Bulk-destructive full-path override: always hard-block regardless of
+		// verb classification (e.g. "sis-imports create" batches a full
+		// institutional import that can't be safely rolled back).
+		return canvasClassIrreversible, gc
+	case isCanvasIrreversibleVerb(sub.Name()):
+		return canvasClassIrreversible, gc
+	case canvasWriteOverridePaths[gc.cli]:
+		return canvasClassWrite, gc
+	case isCanvasReadVerb(sub.Name()):
+		return canvasClassRead, gc
+	default:
+		return canvasClassWrite, gc
+	}
+}
+
+// walkCanvasCommands visits every command below root, leaves first.
+func walkCanvasCommands(root *cobra.Command, visit func(*cobra.Command)) {
 	var walk func(c *cobra.Command)
 	walk = func(c *cobra.Command) {
 		for _, sub := range c.Commands() {
 			// Recurse first so we always visit leaves.
 			walk(sub)
-
-			if !sub.Runnable() || sub.Hidden || sub.Name() == "help" {
-				continue
-			}
-
-			group := topLevelGroup(sub)
-
-			// Skip the "api" raw-escape command — it is documented separately
-			// in the hook script header and cannot be safely classified by verb.
-			if group == "api" || sub.Name() == "api" {
-				continue
-			}
-
-			// Skip local/utility groups that never hit the Canvas API.
-			if canvasLocalGroups[group] {
-				continue
-			}
-
-			cliPath := strings.TrimPrefix(sub.CommandPath(), root.Name()+" ")
-			gc := canvasGuardCmd{
-				cli:  cliPath,
-				tool: strings.ReplaceAll(sub.CommandPath(), " ", "_"),
-				verb: sub.Name(),
-			}
-
-			// Bulk-destructive full-path override: always hard-block regardless
-			// of verb classification (e.g. "sis-imports create" batches a
-			// full institutional import that can't be safely rolled back).
-			if canvasBulkDestructivePaths[cliPath] {
-				irreversible = append(irreversible, gc)
-				continue
-			}
-
-			// Fail-safe ordering: hard-block irreversible verbs, allow only
-			// explicit reads, and treat everything else — known writes AND any
-			// verb the guard doesn't recognize — as a write requiring approval.
-			switch {
-			case isCanvasIrreversibleVerb(sub.Name()):
-				irreversible = append(irreversible, gc)
-			case canvasWriteOverridePaths[cliPath]:
-				writes = append(writes, gc)
-			case isCanvasReadVerb(sub.Name()):
-				read = append(read, gc)
-			default:
-				writes = append(writes, gc)
-			}
+			visit(sub)
 		}
 	}
 	walk(root)
+}
+
+// classifyCanvasCommands walks the command tree and buckets every runnable
+// leaf command into read, write, or irreversible. Commands under local/utility
+// top-level groups (auth, config, cache, agent, etc.) are excluded entirely —
+// they never call the Canvas API.
+func classifyCanvasCommands(root *cobra.Command) (read, writes, irreversible []canvasGuardCmd) {
+	walkCanvasCommands(root, func(sub *cobra.Command) {
+		class, gc := classifyCanvasCommand(root, sub)
+		switch class {
+		case canvasClassRead:
+			read = append(read, gc)
+		case canvasClassWrite:
+			writes = append(writes, gc)
+		case canvasClassIrreversible:
+			irreversible = append(irreversible, gc)
+		case canvasClassSkip, canvasClassLocal:
+			// Not gated by the guard.
+		}
+	})
 	sortCanvasGuard(read)
 	sortCanvasGuard(writes)
 	sortCanvasGuard(irreversible)

--- a/commands/coverage_extra_test.go
+++ b/commands/coverage_extra_test.go
@@ -421,9 +421,6 @@ func TestTelemetryClearCmd_ViaConstructor(t *testing.T) {
 
 func TestSkillsPathCmd_ViaConstructor(t *testing.T) {
 	cmd := newSkillsPathCmd()
-	if cmd == nil {
-		t.Fatal("expected non-nil command")
-	}
 	// RunE just calls runSkillsPath which prints the path — just verify it exists
 	if cmd.RunE == nil && cmd.Run == nil {
 		t.Error("expected RunE or Run to be set")

--- a/commands/global_options_test.go
+++ b/commands/global_options_test.go
@@ -25,9 +25,6 @@ func TestGetGlobalOptions_Defaults(t *testing.T) {
 	outputFormat = "table"
 
 	opts := GetGlobalOptions()
-	if opts == nil {
-		t.Fatal("GetGlobalOptions returned nil")
-	}
 	if opts.Verbose != false {
 		t.Errorf("expected Verbose=false, got %v", opts.Verbose)
 	}

--- a/commands/mcp_annotations.go
+++ b/commands/mcp_annotations.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"strconv"
+
+	"github.com/njayp/ophis"
+	"github.com/spf13/cobra"
+)
+
+// canvasLocalReadPaths is a hand-maintained allowlist of CLI paths under
+// canvasLocalGroups that only read state. Those groups never touch the Canvas
+// API, so classifyCanvasCommand returns canvasClassLocal for them and the
+// verb-based read allowlist does not apply — "config account" and "context set"
+// both end in tokens that look inert but write to local config.
+//
+// The value is the command's openWorldHint: true when it reaches the network.
+//
+// Misses are safe: an unlisted command emits no annotations and is therefore
+// dropped by read-only MCP clients, never silently exposed as a read.
+var canvasLocalReadPaths = map[string]bool{
+	"alias list":       false,
+	"auth status":      false,
+	"cache stats":      false,
+	"config list":      false,
+	"config show":      false,
+	"context show":     false,
+	"doctor":           true, // probes Canvas connectivity
+	"skills path":      false,
+	"skills print":     false,
+	"telemetry show":   false,
+	"telemetry status": false,
+	"update check":     true, // queries the GitHub releases API
+	"update status":    false,
+	"version":          false,
+	"webhook events":   false, // prints the static event-type catalog
+}
+
+// applyMCPAnnotations stamps MCP tool annotations onto every command in the
+// tree, derived from classifyCanvasCommand so the hints can never contradict
+// what "canvas agent guard" gates.
+//
+// This exists because MCP clients running in read-only mode allow a tool only
+// when annotations.readOnlyHint is strictly true. A missing annotation counts
+// as a write, not as unknown, so without this every tool is filtered out and
+// the whole server is dropped. See issue #58.
+//
+// Must run before the "mcp" subcommand executes — ophis builds its tool list
+// from cmd.Annotations at run time, in registerTools. Execute calls it.
+//
+// Deliberately unannotated (and therefore invisible to read-only clients):
+//   - "canvas api", which can issue any HTTP verb
+//   - every local command not in canvasLocalReadPaths
+func applyMCPAnnotations(root *cobra.Command) {
+	walkCanvasCommands(root, func(sub *cobra.Command) {
+		class, gc := classifyCanvasCommand(root, sub)
+		switch class {
+		case canvasClassRead:
+			setMCPAnnotations(sub, true, false, true)
+		case canvasClassWrite:
+			// destructiveHint is left unset: MCP clients default it to true,
+			// which is the conservative reading for an update that overwrites
+			// fields. Only the irreversible bucket asserts it outright.
+			setMCPAnnotations(sub, false, false, true)
+		case canvasClassIrreversible:
+			setMCPAnnotations(sub, false, true, true)
+		case canvasClassLocal:
+			if openWorld, ok := canvasLocalReadPaths[gc.cli]; ok {
+				setMCPAnnotations(sub, true, false, openWorld)
+			}
+		case canvasClassSkip:
+			// Never annotated — see the doc comment.
+		}
+	})
+}
+
+// setMCPAnnotations merges MCP hints into cmd.Annotations, preserving any
+// unrelated keys cobra or the command itself already set.
+//
+// destructiveHint is only ever written when true; omitting it lets the client
+// apply the spec default (true when readOnlyHint is false), which fails safe.
+func setMCPAnnotations(cmd *cobra.Command, readOnly, destructive, openWorld bool) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[ophis.AnnotationReadOnly] = strconv.FormatBool(readOnly)
+	cmd.Annotations[ophis.AnnotationOpenWorld] = strconv.FormatBool(openWorld)
+	if destructive {
+		cmd.Annotations[ophis.AnnotationDestructive] = "true"
+	}
+}

--- a/commands/mcp_annotations_test.go
+++ b/commands/mcp_annotations_test.go
@@ -1,0 +1,257 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/njayp/ophis"
+	"github.com/spf13/cobra"
+)
+
+// findCmd resolves a space-separated CLI path (without the root name) to its
+// command, or nil.
+func findCmd(root *cobra.Command, path string) *cobra.Command {
+	cur := root
+	for _, part := range strings.Fields(path) {
+		var next *cobra.Command
+		for _, sub := range cur.Commands() {
+			if sub.Name() == part {
+				next = sub
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		cur = next
+	}
+	return cur
+}
+
+func annotationOf(cmd *cobra.Command, key string) (string, bool) {
+	if cmd == nil || cmd.Annotations == nil {
+		return "", false
+	}
+	v, ok := cmd.Annotations[key]
+	return v, ok
+}
+
+func assertReadOnly(t *testing.T, root *cobra.Command, path, want string) {
+	t.Helper()
+	cmd := findCmd(root, path)
+	if cmd == nil {
+		t.Fatalf("command %q not found in tree", path)
+	}
+	got, ok := annotationOf(cmd, ophis.AnnotationReadOnly)
+	if want == "" {
+		if ok {
+			t.Errorf("%q: expected no readOnlyHint, got %q", path, got)
+		}
+		return
+	}
+	if !ok {
+		t.Errorf("%q: expected readOnlyHint=%s, got no annotation", path, want)
+		return
+	}
+	if got != want {
+		t.Errorf("%q: expected readOnlyHint=%s, got %s", path, want, got)
+	}
+}
+
+// TestApplyMCPAnnotations_MatchesGuardClassification is the anti-drift guard: a
+// command must never advertise readOnlyHint:true over MCP while "canvas agent
+// guard" gates it as a write or hard-blocks it. Both derive from
+// classifyCanvasCommand, and this asserts they cannot diverge on the real tree.
+func TestApplyMCPAnnotations_MatchesGuardClassification(t *testing.T) {
+	root := rootCmd
+	applyMCPAnnotations(root)
+
+	read, writes, irreversible := classifyCanvasCommands(root)
+
+	if len(read) == 0 || len(writes) == 0 || len(irreversible) == 0 {
+		t.Fatalf("real tree produced empty buckets: read=%d writes=%d irreversible=%d",
+			len(read), len(writes), len(irreversible))
+	}
+
+	for _, c := range read {
+		assertReadOnly(t, root, c.cli, "true")
+	}
+	for _, c := range writes {
+		assertReadOnly(t, root, c.cli, "false")
+		// Ordinary writes must not claim to be non-destructive; the hint is
+		// left unset so clients apply the conservative spec default.
+		if v, ok := annotationOf(findCmd(root, c.cli), ophis.AnnotationDestructive); ok {
+			t.Errorf("%q: write should not set destructiveHint, got %q", c.cli, v)
+		}
+	}
+	for _, c := range irreversible {
+		assertReadOnly(t, root, c.cli, "false")
+		if v, _ := annotationOf(findCmd(root, c.cli), ophis.AnnotationDestructive); v != "true" {
+			t.Errorf("%q: irreversible should set destructiveHint=true, got %q", c.cli, v)
+		}
+	}
+}
+
+// TestApplyMCPAnnotations_APIEscapeHatchUnannotated pins the one deliberate
+// exception: "canvas api" can issue any HTTP verb, so it must stay unannotated
+// and therefore be filtered out by read-only MCP clients.
+func TestApplyMCPAnnotations_APIEscapeHatchUnannotated(t *testing.T) {
+	root := rootCmd
+	applyMCPAnnotations(root)
+
+	apiCmd := findCmd(root, "api")
+	if apiCmd == nil {
+		t.Fatal(`"canvas api" not found in tree`)
+	}
+	if _, ok := annotationOf(apiCmd, ophis.AnnotationReadOnly); ok {
+		t.Error(`"canvas api" must not carry a readOnlyHint`)
+	}
+	for _, sub := range apiCmd.Commands() {
+		if _, ok := annotationOf(sub, ophis.AnnotationReadOnly); ok {
+			t.Errorf("%q must not carry a readOnlyHint", sub.CommandPath())
+		}
+	}
+}
+
+// TestApplyMCPAnnotations_LocalGroups verifies the hand-maintained local
+// allowlist: read-only local commands are annotated, and local commands that
+// mutate state stay unannotated even when their leaf name looks inert.
+func TestApplyMCPAnnotations_LocalGroups(t *testing.T) {
+	root := rootCmd
+	applyMCPAnnotations(root)
+
+	for _, path := range []string{
+		"version", "doctor", "auth status", "config show", "config list",
+		"cache stats", "telemetry status", "update check", "webhook events",
+	} {
+		assertReadOnly(t, root, path, "true")
+	}
+
+	// These mutate local state and must be filtered out by read-only clients.
+	// "config account" is the trap: it sets the default account ID.
+	for _, path := range []string{
+		"auth login", "auth logout", "config account", "config use",
+		"context set", "cache clear", "skills install", "telemetry enable",
+		"update", "webhook listen", "repl",
+	} {
+		assertReadOnly(t, root, path, "")
+	}
+}
+
+// TestCanvasLocalReadPaths_ResolveToRealCommands stops the allowlist going
+// stale: an entry that no longer matches a command (renamed or removed) would
+// silently stop annotating it.
+func TestCanvasLocalReadPaths_ResolveToRealCommands(t *testing.T) {
+	for path := range canvasLocalReadPaths {
+		cmd := findCmd(rootCmd, path)
+		if cmd == nil {
+			t.Errorf("canvasLocalReadPaths entry %q matches no command", path)
+			continue
+		}
+		if !cmd.Runnable() {
+			t.Errorf("canvasLocalReadPaths entry %q is not runnable", path)
+		}
+		if class, _ := classifyCanvasCommand(rootCmd, cmd); class != canvasClassLocal {
+			t.Errorf("canvasLocalReadPaths entry %q classifies as %v, want local", path, class)
+		}
+	}
+}
+
+func TestApplyMCPAnnotations_TestTree(t *testing.T) {
+	root := buildTestTree()
+	applyMCPAnnotations(root)
+
+	assertReadOnly(t, root, "courses list", "true")
+	assertReadOnly(t, root, "courses get", "true")
+	assertReadOnly(t, root, "courses create", "false")
+	assertReadOnly(t, root, "courses delete", "false")
+	assertReadOnly(t, root, "api GET", "")
+	assertReadOnly(t, root, "auth login", "")
+
+	if v, _ := annotationOf(findCmd(root, "courses delete"), ophis.AnnotationDestructive); v != "true" {
+		t.Errorf(`"courses delete" destructiveHint = %q, want "true"`, v)
+	}
+	if v, _ := annotationOf(findCmd(root, "courses list"), ophis.AnnotationOpenWorld); v != "true" {
+		t.Errorf(`"courses list" openWorldHint = %q, want "true"`, v)
+	}
+}
+
+// TestApplyMCPAnnotations_UnknownVerbNotReadOnly mirrors the guard's fail-safe
+// default: a verb the classifier does not recognize must never be advertised
+// as read-only.
+func TestApplyMCPAnnotations_UnknownVerbNotReadOnly(t *testing.T) {
+	root := &cobra.Command{Use: "canvas"}
+	grp := &cobra.Command{Use: "widgets"}
+	grp.AddCommand(&cobra.Command{
+		Use:  "frobnicate",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	})
+	root.AddCommand(grp)
+
+	applyMCPAnnotations(root)
+
+	assertReadOnly(t, root, "widgets frobnicate", "false")
+}
+
+func TestSetMCPAnnotations_PreservesUnrelatedKeys(t *testing.T) {
+	cmd := &cobra.Command{Use: "thing", Annotations: map[string]string{"custom": "kept"}}
+
+	setMCPAnnotations(cmd, true, false, false)
+
+	if cmd.Annotations["custom"] != "kept" {
+		t.Errorf("unrelated annotation clobbered: %v", cmd.Annotations)
+	}
+	if cmd.Annotations[ophis.AnnotationReadOnly] != "true" {
+		t.Errorf("readOnlyHint = %q, want true", cmd.Annotations[ophis.AnnotationReadOnly])
+	}
+	if cmd.Annotations[ophis.AnnotationOpenWorld] != "false" {
+		t.Errorf("openWorldHint = %q, want false", cmd.Annotations[ophis.AnnotationOpenWorld])
+	}
+	if _, ok := cmd.Annotations[ophis.AnnotationDestructive]; ok {
+		t.Error("destructiveHint should be omitted when false")
+	}
+}
+
+func TestSetMCPAnnotations_NilMap(t *testing.T) {
+	cmd := &cobra.Command{Use: "thing"}
+
+	setMCPAnnotations(cmd, false, true, true)
+
+	if cmd.Annotations[ophis.AnnotationReadOnly] != "false" {
+		t.Errorf("readOnlyHint = %q, want false", cmd.Annotations[ophis.AnnotationReadOnly])
+	}
+	if cmd.Annotations[ophis.AnnotationDestructive] != "true" {
+		t.Errorf("destructiveHint = %q, want true", cmd.Annotations[ophis.AnnotationDestructive])
+	}
+}
+
+// TestApplyMCPAnnotations_Idempotent guards against Execute and ExecuteContext
+// both running the walk, and against tests dispatching through rootCmd repeatedly.
+func TestApplyMCPAnnotations_Idempotent(t *testing.T) {
+	root := buildTestTree()
+
+	applyMCPAnnotations(root)
+	first := map[string]string{}
+	walkCanvasCommands(root, func(c *cobra.Command) {
+		if v, ok := annotationOf(c, ophis.AnnotationReadOnly); ok {
+			first[c.CommandPath()] = v
+		}
+	})
+
+	applyMCPAnnotations(root)
+	second := map[string]string{}
+	walkCanvasCommands(root, func(c *cobra.Command) {
+		if v, ok := annotationOf(c, ophis.AnnotationReadOnly); ok {
+			second[c.CommandPath()] = v
+		}
+	})
+
+	if len(first) != len(second) {
+		t.Fatalf("annotation count changed: %d then %d", len(first), len(second))
+	}
+	for path, v := range first {
+		if second[path] != v {
+			t.Errorf("%q: %q then %q", path, v, second[path])
+		}
+	}
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -96,6 +96,11 @@ func Execute(v, c, bd string) error {
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate("canvas-cli version {{.Version}}\n")
 
+	// Stamp MCP tool annotations. Done here rather than in an init() because
+	// the tree is assembled across many packages' init() functions; ophis reads
+	// cmd.Annotations when the "mcp" subcommand runs, so this is early enough.
+	applyMCPAnnotations(rootCmd)
+
 	return rootCmd.Execute()
 }
 
@@ -107,6 +112,8 @@ func ExecuteContext(ctx context.Context, v, c, bd string) error {
 
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate("canvas-cli version {{.Version}}\n")
+
+	applyMCPAnnotations(rootCmd)
 
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/commands/root_extra_test.go
+++ b/commands/root_extra_test.go
@@ -7,9 +7,6 @@ import (
 
 func TestGetRootCmd_NotNil(t *testing.T) {
 	cmd := GetRootCmd()
-	if cmd == nil {
-		t.Fatal("GetRootCmd returned nil")
-	}
 	if cmd.Use != "canvas" {
 		t.Errorf("expected Use=canvas, got %q", cmd.Use)
 	}

--- a/commands/webhook_test.go
+++ b/commands/webhook_test.go
@@ -51,9 +51,6 @@ func TestWebhookListenCmd_ValidationError(t *testing.T) {
 	// The WebhookListenOptions.Validate passes with default values (no required fields).
 	// We just verify the command structure is correct and can be built.
 	cmd := newWebhookListenCmd()
-	if cmd == nil {
-		t.Fatal("expected non-nil webhook listen command")
-	}
 	if cmd.Use != "listen" {
 		t.Errorf("expected Use='listen', got: %q", cmd.Use)
 	}
@@ -61,9 +58,6 @@ func TestWebhookListenCmd_ValidationError(t *testing.T) {
 
 func TestWebhookEventsCmd_Structure(t *testing.T) {
 	cmd := newWebhookEventsCmd()
-	if cmd == nil {
-		t.Fatal("expected non-nil webhook events command")
-	}
 	if cmd.Use != "events" {
 		t.Errorf("expected Use='events', got: %q", cmd.Use)
 	}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,20 @@ sync by `make docs-gen` and the documentation workflow.
 
 ## [Unreleased]
 
+### Added
+
+- MCP tools now emit per-tool annotations (`readOnlyHint`, `destructiveHint`,
+  `openWorldHint`). Clients that enforce a read-only session allow a tool only
+  when `readOnlyHint` is strictly `true` and treat a missing annotation as a
+  write, so previously every tool was filtered out and the whole server was
+  dropped. 247 of 533 tools are now marked read-only. ([#58](https://github.com/jjuanrivvera/canvas-cli/issues/58))
+
+  The hints are derived from the same classification `canvas agent guard` uses,
+  so a tool cannot advertise itself as read-only while the guard gates it as a
+  write. `canvas api` and local commands that mutate state (`auth login`,
+  `config account`, `cache clear`, …) are deliberately left unannotated and are
+  therefore dropped by read-only clients.
+
 ### Planned
 
 - Canvas Studio integration

--- a/docs/user-guide/mcp.md
+++ b/docs/user-guide/mcp.md
@@ -210,6 +210,41 @@ For safety, inherited flags below are excluded from MCP exposure:
 - `--show-token`
 - `--config`
 
+## Tool Annotations and Read-Only Clients
+
+Every tool carries MCP annotations describing what it does, so clients can
+decide what to auto-approve:
+
+| Annotation | Meaning |
+|---|---|
+| `readOnlyHint: true` | Reads only — `list`, `get`, `show`, … |
+| `readOnlyHint: false` | Writes — `create`, `update`, `grade`, … |
+| `destructiveHint: true` | Cannot be undone — `delete`, `conclude`, `crosslist`, … |
+
+The hints are derived from the same classification `canvas agent guard` uses, so
+a tool can never advertise itself as read-only while the guard gates it as a
+write. See [Agent Safety](agent-safety.md).
+
+Some clients run their MCP session in read-only mode and only allow a tool when
+`readOnlyHint` is strictly `true`. A tool with no annotation counts as a write,
+not as unknown. In those clients the write and destructive tools are filtered
+out and the read tools remain usable.
+
+Two kinds of tool are deliberately left unannotated, so read-only clients drop
+them entirely:
+
+- **`canvas api`** — the raw escape hatch can issue any HTTP verb, so no
+  read-only claim can be made about it.
+- **Local commands that mutate state** — `auth login`, `config set`,
+  `config account`, `cache clear`, `skills install`, `update`, and similar.
+
+To inspect what your client will see:
+
+```bash
+canvas mcp tools   # writes mcp-tools.json in the current directory
+jq '[.[] | select(.annotations.readOnlyHint == true)] | length' mcp-tools.json
+```
+
 ## `--instance` in MCP Calls
 
 Use the same flag name under MCP `flags` as in CLI:
@@ -248,6 +283,20 @@ canvas mcp tools
 - Restart the client after adding MCP server
 - Confirm command path is absolute (for example `/opt/homebrew/bin/canvas`)
 - Run `canvas mcp tools` to verify server-side tool discovery
+
+### Server dropped by a read-only client
+
+The client reports that the server has no available tools after filtering, and
+drops it. This means it is enforcing read-only mode and found no tool with
+`readOnlyHint: true`. Check what your build emits:
+
+```bash
+canvas mcp tools
+jq '[.[] | select(.annotations.readOnlyHint == true)] | length' mcp-tools.json
+```
+
+A count of `0` means the build predates tool annotations — upgrade. Anything
+above zero means the server will survive filtering.
 
 ### Using wrong Canvas environment
 


### PR DESCRIPTION
Fixes #58.

Every tool exported with `annotations: null`. Clients that enforce a read-only session only allow a tool when `readOnlyHint` is strictly true, and treat a missing annotation as a write rather than as unknown — so the entire server got filtered out.

ophis v1.1.4 already reads `cmd.Annotations` into MCP tool annotations, so this is wiring, not a dependency change.

## Result

| | tools |
|---|---|
| `readOnlyHint: true` | 247 |
| writes | 179 |
| irreversible (`destructiveHint: true`) | 83 |
| unannotated on purpose | 24 |

## How

`classifyCanvasCommand` is split out of `classifyCanvasCommands` so the guard and the annotations share one classifier. A tool can no longer advertise itself as read-only while `agent guard` gates it as a write. Guard behaviour is unchanged and its existing tests pass untouched.

Ordinary writes leave `destructiveHint` unset so clients apply the conservative default; only the irreversible bucket asserts it.

`canvas api` stays unannotated because it can issue any HTTP verb. Local commands that mutate state (`auth login`, `config account`, `cache clear`, ...) stay unannotated too and get dropped by read-only clients, which is what we want. The 14 local read-only commands are annotated via a small allowlist, with a test that fails if an entry stops matching a real command.

## Tests

9 new tests, including one asserting annotations match guard classification across the real tree. Coverage 81.2% total, new code 100%. `make check` passes.

The second commit is unrelated hygiene: four dead nil checks that only staticcheck on darwin flagged.